### PR TITLE
feat: add tags to the temporary server

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -99,6 +99,8 @@ type Config struct {
 
 	// RemoveVolume remove the temporary volumes created before running the server
 	RemoveVolume bool `mapstructure:"remove_volume"`
+	// KeepServer prevents the termination of the temporary server after the build. Used for testing purposes.
+	KeepServer bool `mapstructure:"keep_server"`
 
 	// RootVolumeType lets you configure the root volume
 	// See the [RootVolume](#root-volume-configuration) documentation for fields.
@@ -128,6 +130,8 @@ type Config struct {
 
 	// A list of tags to apply on the created image, volumes, and snapshots
 	Tags []string `mapstructure:"tags" required:"false"`
+	// A list of tags to apply on the temporary server
+	ServerTags []string `mapstructure:"server_tags" required:"false"`
 
 	// A list of private network IDs to attach to the instance during the build
 	PrivateNetworkIDs []string `mapstructure:"private_network_ids" required:"false"`

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -80,6 +80,7 @@ type FlatConfig struct {
 	Bootscript                *string                 `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
 	BootType                  *string                 `mapstructure:"boottype" required:"false" cty:"boottype" hcl:"boottype"`
 	RemoveVolume              *bool                   `mapstructure:"remove_volume" cty:"remove_volume" hcl:"remove_volume"`
+	KeepServer                *bool                   `mapstructure:"keep_server" cty:"keep_server" hcl:"keep_server"`
 	RootVolume                *FlatConfigRootVolume   `mapstructure:"root_volume" required:"false" cty:"root_volume" hcl:"root_volume"`
 	BlockVolumes              []FlatConfigBlockVolume `mapstructure:"block_volume" cty:"block_volume" hcl:"block_volume"`
 	CleanupMachineRelatedData *string                 `mapstructure:"cleanup_machine_related_data" required:"false" cty:"cleanup_machine_related_data" hcl:"cleanup_machine_related_data"`
@@ -90,6 +91,7 @@ type FlatConfig struct {
 	UserData                  map[string]string       `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	UserDataTimeout           *string                 `mapstructure:"user_data_timeout" required:"false" cty:"user_data_timeout" hcl:"user_data_timeout"`
 	Tags                      []string                `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
+	ServerTags                []string                `mapstructure:"server_tags" required:"false" cty:"server_tags" hcl:"server_tags"`
 	PrivateNetworkIDs         []string                `mapstructure:"private_network_ids" required:"false" cty:"private_network_ids" hcl:"private_network_ids"`
 	Token                     *string                 `mapstructure:"api_token" required:"false" cty:"api_token" hcl:"api_token"`
 	Organization              *string                 `mapstructure:"organization_id" required:"false" cty:"organization_id" hcl:"organization_id"`
@@ -178,6 +180,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"bootscript":                   &hcldec.AttrSpec{Name: "bootscript", Type: cty.String, Required: false},
 		"boottype":                     &hcldec.AttrSpec{Name: "boottype", Type: cty.String, Required: false},
 		"remove_volume":                &hcldec.AttrSpec{Name: "remove_volume", Type: cty.Bool, Required: false},
+		"keep_server":                  &hcldec.AttrSpec{Name: "keep_server", Type: cty.Bool, Required: false},
 		"root_volume":                  &hcldec.BlockSpec{TypeName: "root_volume", Nested: hcldec.ObjectSpec((*FlatConfigRootVolume)(nil).HCL2Spec())},
 		"block_volume":                 &hcldec.BlockListSpec{TypeName: "block_volume", Nested: hcldec.ObjectSpec((*FlatConfigBlockVolume)(nil).HCL2Spec())},
 		"cleanup_machine_related_data": &hcldec.AttrSpec{Name: "cleanup_machine_related_data", Type: cty.String, Required: false},
@@ -188,6 +191,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.Map(cty.String), Required: false},
 		"user_data_timeout":            &hcldec.AttrSpec{Name: "user_data_timeout", Type: cty.String, Required: false},
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.List(cty.String), Required: false},
+		"server_tags":                  &hcldec.AttrSpec{Name: "server_tags", Type: cty.List(cty.String), Required: false},
 		"private_network_ids":          &hcldec.AttrSpec{Name: "private_network_ids", Type: cty.List(cty.String), Required: false},
 		"api_token":                    &hcldec.AttrSpec{Name: "api_token", Type: cty.String, Required: false},
 		"organization_id":              &hcldec.AttrSpec{Name: "organization_id", Type: cty.String, Required: false},

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -24,13 +24,12 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	instanceAPI := instance.NewAPI(state.Get("client").(*scw.Client))
 	ui := state.Get("ui").(packersdk.Ui)
 	c := state.Get("config").(*Config)
-
-	var tags []string
+	tags := c.Tags
 
 	ui.Say("Creating server...")
 
 	if c.Comm.SSHPublicKey != nil {
-		tags = []string{"AUTHORIZED_KEY=" + strings.ReplaceAll(strings.TrimSpace(string(c.Comm.SSHPublicKey)), " ", "_")}
+		tags = append(tags, "AUTHORIZED_KEY="+strings.ReplaceAll(strings.TrimSpace(string(c.Comm.SSHPublicKey)), " ", "_"))
 	}
 
 	bootType := instance.BootType(c.BootType)

--- a/builder/scaleway/step_create_server.go
+++ b/builder/scaleway/step_create_server.go
@@ -24,7 +24,12 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 	instanceAPI := instance.NewAPI(state.Get("client").(*scw.Client))
 	ui := state.Get("ui").(packersdk.Ui)
 	c := state.Get("config").(*Config)
-	tags := c.Tags
+
+	// Add specific server_tags if provided, else apply the tags
+	tags := c.ServerTags
+	if len(tags) == 0 {
+		tags = c.Tags
+	}
 
 	ui.Say("Creating server...")
 
@@ -125,7 +130,7 @@ func (s *stepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 }
 
 func (s *stepCreateServer) Cleanup(state multistep.StateBag) {
-	if s.serverID == "" {
+	if s.serverID == "" || state.Get("config").(*Config).KeepServer {
 		return
 	}
 

--- a/docs-partials/builder/scaleway/Config-not-required.mdx
+++ b/docs-partials/builder/scaleway/Config-not-required.mdx
@@ -21,6 +21,8 @@
 
 - `remove_volume` (bool) - RemoveVolume remove the temporary volumes created before running the server
 
+- `keep_server` (bool) - KeepServer prevents the termination of the temporary server after the build. Used for testing purposes.
+
 - `root_volume` (ConfigRootVolume) - RootVolumeType lets you configure the root volume
   See the [RootVolume](#root-volume-configuration) documentation for fields.
 
@@ -43,6 +45,8 @@
 - `user_data_timeout` (duration string | ex: "1h5m2s") - A custom timeout for user data to assure its completion. Defaults to "0s"
 
 - `tags` ([]string) - A list of tags to apply on the created image, volumes, and snapshots
+
+- `server_tags` ([]string) - A list of tags to apply on the temporary server
 
 - `private_network_ids` ([]string) - A list of private network IDs to attach to the instance during the build
 

--- a/internal/checks/server.go
+++ b/internal/checks/server.go
@@ -1,0 +1,116 @@
+package checks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/scaleway/packer-plugin-scaleway/internal/tester"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+var _ tester.PackerCheck = (*ServerCheck)(nil)
+
+type ServerCheck struct {
+	zone scw.Zone
+	name string
+
+	tags []string
+}
+
+func Server(zone scw.Zone, name string) *ServerCheck {
+	return &ServerCheck{
+		zone: zone,
+		name: name,
+	}
+}
+
+func (c *ServerCheck) Tags(tags []string) *ServerCheck {
+	c.tags = tags
+
+	return c
+}
+
+func findServer(ctx context.Context, zone scw.Zone, name string) (*instance.Server, error) {
+	testCtx := tester.ExtractCtx(ctx)
+	api := instance.NewAPI(testCtx.ScwClient)
+
+	resp, err := api.ListServers(&instance.ListServersRequest{
+		Zone:    zone,
+		Name:    &name,
+		Project: &testCtx.ProjectID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list instance servers: %w", err)
+	}
+
+	if len(resp.Servers) == 0 {
+		return nil, fmt.Errorf("no instance server named %q was found", name)
+	}
+
+	if len(resp.Servers) > 1 {
+		return nil, fmt.Errorf("multiple instance servers found with name %q", name)
+	}
+
+	return resp.Servers[0], nil
+}
+
+func (c *ServerCheck) CheckName() string {
+	return fmt.Sprintf("Instance server \"%s...\"", c.name)
+}
+
+func (c *ServerCheck) Check(ctx context.Context) error {
+	server, err := findServer(ctx, c.zone, c.name)
+	if err != nil {
+		return err
+	}
+
+	actualTags := make(map[string]bool, len(server.Tags))
+	for _, tag := range server.Tags {
+		actualTags[tag] = false
+	}
+
+	expectedTags := make(map[string]bool, len(c.tags))
+	for _, tag := range c.tags {
+		expectedTags[tag] = false
+	}
+
+	for serverTag := range actualTags {
+		for tagToFind := range expectedTags {
+			if serverTag == tagToFind {
+				actualTags[serverTag] = true
+				expectedTags[tagToFind] = true
+
+				break
+			}
+
+			if strings.HasPrefix(serverTag, "AUTHORIZED_KEY=") {
+				actualTags[serverTag] = true
+
+				break
+			}
+		}
+	}
+
+	errs := []error{errors.New("server tags did not match")}
+
+	for expectedTag, found := range expectedTags {
+		if !found {
+			errs = append(errs, fmt.Errorf("- missing expected tag: %q", expectedTag))
+		}
+	}
+
+	for actualTag, expected := range actualTags {
+		if !expected {
+			errs = append(errs, fmt.Errorf("+ found unexpected tag: %q", actualTag))
+		}
+	}
+
+	if len(errs) > 1 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}

--- a/internal/cleanup/server.go
+++ b/internal/cleanup/server.go
@@ -1,0 +1,61 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/scaleway/packer-plugin-scaleway/internal/tester"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+var _ tester.PackerCleanup = (*ServerCleanup)(nil)
+
+type ServerCleanup struct {
+	zone scw.Zone
+	name string
+}
+
+func Server(zone scw.Zone, name string) *ServerCleanup {
+	return &ServerCleanup{
+		zone: zone,
+		name: name,
+	}
+}
+
+func (i *ServerCleanup) Cleanup(ctx context.Context, t *testing.T) error {
+	t.Helper()
+
+	testCtx := tester.ExtractCtx(ctx)
+	api := instance.NewAPI(testCtx.ScwClient)
+
+	resp, err := api.ListServers(&instance.ListServersRequest{
+		Name:    &i.name,
+		Zone:    i.zone,
+		Project: &testCtx.ProjectID,
+	}, scw.WithAllPages(), scw.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to list instance servers: %w", err)
+	}
+
+	if len(resp.Servers) == 0 {
+		return fmt.Errorf("could not find any instance server named %q", i.name)
+	}
+
+	if len(resp.Servers) > 1 {
+		return fmt.Errorf("found multiple instance servers named %q", i.name)
+	}
+
+	err = api.DeleteServer(&instance.DeleteServerRequest{
+		Zone:     i.zone,
+		ServerID: resp.Servers[0].ID,
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to delete instance server: %w", err)
+	}
+
+	t.Logf("deleted instance server %q\n", resp.Servers[0].Name)
+
+	return nil
+}

--- a/internal/tests/complete_test.go
+++ b/internal/tests/complete_test.go
@@ -13,6 +13,7 @@ import (
 func TestComplete(t *testing.T) {
 	zone := scw.ZoneNlAms1
 	imageName := "packer-e2e-complete"
+	serverName := "packer-tmp-server"
 	rootVolumeSize := 12
 	blockVolumeSize := 10
 
@@ -23,10 +24,14 @@ func TestComplete(t *testing.T) {
 			  commercial_type = "DEV1-M"
 			  zone = "%[1]s"
 			  image = "ubuntu_jammy"
-			  image_name = "%[2]s"
 			  ssh_username = "root"
-			  remove_volume = false
+
+			  image_name = "%[2]s"
               tags = [ "%[5]s", "%[6]s", "%[7]s" ]
+			  server_name = "%[8]s"
+			  server_tags = [ "packer-build", "tmp-server" ]
+			  remove_volume = false
+			  keep_server = true
 
 			  root_volume {
 				type = "l_ssd"
@@ -55,7 +60,7 @@ func TestComplete(t *testing.T) {
 			build {
 			  sources = ["source.scaleway.basic"]
 			}
-			`, zone, imageName, rootVolumeSize, blockVolumeSize, tagTest, tagPacker, tagComplete),
+			`, zone, imageName, rootVolumeSize, blockVolumeSize, tagTest, tagPacker, tagComplete, serverName),
 		Checks: []tester.PackerCheck{
 			checks.Image(zone, imageName).
 				SizeInGB(42).
@@ -96,8 +101,11 @@ func TestComplete(t *testing.T) {
 				SizeInGB(uint64(blockVolumeSize)).
 				IOPS(5000).
 				Tags(e2eTagsComplete),
+			checks.Server(zone, serverName).
+				Tags([]string{"packer-build", "tmp-server"}),
 		},
 		Cleanup: []tester.PackerCleanup{
+			cleanup.Server(zone, serverName),
 			cleanup.Image(zone, imageName),
 			cleanup.InstanceSnapshot(zone, "named"),
 			cleanup.InstanceVolume(zone, rootVolumeNamePrefix),

--- a/internal/tests/testdata/complete.cassette.yaml
+++ b/internal/tests/testdata/complete.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images?name=packer-e2e-complete&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -25,7 +25,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 956
-        body: '{"images": [{"id": "911efd53-5dce-4899-8c3f-84346acc192f", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"2": {"volume_type": "sbs_snapshot", "id": "f8cb373c-487f-4909-9a17-a29f3613ed28", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "size": 0, "name": ""}, "3": {"volume_type": "sbs_snapshot", "id": "8afe97a2-26c5-4567-84ad-5431f6eb8834", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:24:40.148524+00:00", "modification_date": "2025-11-27T17:24:40.148524+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
+        body: '{"images": [{"id": "6d100f83-b1ca-4374-97d0-56b353d26a12", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"3": {"volume_type": "sbs_snapshot", "id": "a22b5977-fd17-4b38-98c4-ca760ed91f3a", "size": 0, "name": ""}, "2": {"volume_type": "sbs_snapshot", "id": "11ae3867-02f7-472e-b966-43b397efc926", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T17:13:51.280221+00:00", "modification_date": "2026-06-02T17:13:51.280221+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
         headers:
             Content-Length:
                 - "956"
@@ -34,11 +34,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:52 GMT
             Link:
                 - </images?page=1&per_page=50&name=packer-e2e-complete&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -46,12 +46,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bf6aa90d-6782-4609-ab27-60f7e00ced8c
+                - ed3009f0-8c47-4492-8865-4a5f40093512
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 233.534858ms
+        duration: 243.627535ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -61,26 +61,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/f8cb373c-487f-4909-9a17-a29f3613ed28
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/11ae3867-02f7-472e-b966-43b397efc926
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 729
-        body: '{"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:40.316749Z", "references":[{"id":"dd246206-3f19-41c5-8f74-6a241bd6dce6", "product_resource_type":"instance_image", "product_resource_id":"911efd53-5dce-4899-8c3f-84346acc192f", "created_at":"2025-11-27T17:24:40.316749Z", "type":"link", "status":"attached"}], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 720
+        body: '{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:51.438467Z","references":[{"id":"c149d75e-7e09-40ad-8fe9-6b0d78f01234","product_resource_type":"instance_image","product_resource_id":"6d100f83-b1ca-4374-97d0-56b353d26a12","created_at":"2026-06-02T17:13:51.438467Z","type":"link","status":"attached"}],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "729"
+                - "720"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -88,10 +88,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f47d7fc3-c75a-41c2-839c-d2d2bf5fe62a
+                - 56d16ae3-32b4-4583-b921-8d6848cafdb1
         status: 200 OK
         code: 200
-        duration: 94.091403ms
+        duration: 73.098222ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -101,26 +101,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/e1d8c1b1-003e-4b92-8802-eb88ec7a86ac
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 705
-        body: '{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:40.233930Z", "references":[{"id":"abc50860-35fc-4242-b30a-91413402a559", "product_resource_type":"instance_image", "product_resource_id":"911efd53-5dce-4899-8c3f-84346acc192f", "created_at":"2025-11-27T17:24:40.233930Z", "type":"link", "status":"attached"}], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 696
+        body: '{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:51.367728Z","references":[{"id":"a31759ca-9340-4bde-b618-cb38f8e8f2f6","product_resource_type":"instance_image","product_resource_id":"6d100f83-b1ca-4374-97d0-56b353d26a12","created_at":"2026-06-02T17:13:51.367728Z","type":"link","status":"attached"}],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "705"
+                - "696"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -128,10 +128,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce3615af-80fe-4ac7-8c39-e16082c2ca57
+                - 7d1740a2-379d-4f52-8d19-15db62924524
         status: 200 OK
         code: 200
-        duration: 83.994716ms
+        duration: 55.268952ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -141,26 +141,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/8afe97a2-26c5-4567-84ad-5431f6eb8834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/a22b5977-fd17-4b38-98c4-ca760ed91f3a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 736
-        body: '{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:40.387862Z", "references":[{"id":"89bb5f83-3b80-4c04-8bbf-871c51ce223a", "product_resource_type":"instance_image", "product_resource_id":"911efd53-5dce-4899-8c3f-84346acc192f", "created_at":"2025-11-27T17:24:40.387862Z", "type":"link", "status":"attached"}], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 727
+        body: '{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:51.494646Z","references":[{"id":"90108b8b-91b8-4567-953b-83c7beecd215","product_resource_type":"instance_image","product_resource_id":"6d100f83-b1ca-4374-97d0-56b353d26a12","created_at":"2026-06-02T17:13:51.494646Z","type":"link","status":"attached"}],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "736"
+                - "727"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:52 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -168,10 +168,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4c005bc4-293d-4828-91fd-e010a4694f9f
+                - 8d8c5fbb-b1f6-47d9-84fe-b4cf332e20a4
         status: 200 OK
         code: 200
-        duration: 91.442742ms
+        duration: 68.972171ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -186,7 +186,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots?name=named-snap-root&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -194,7 +194,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"snapshots": [{"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2025-11-27T17:24:23.714819+00:00", "modification_date": "2025-11-27T17:24:23.714819+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}]}'
+        body: '{"snapshots": [{"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2026-06-02T17:13:50.977152+00:00", "modification_date": "2026-06-02T17:13:50.977152+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}]}'
         headers:
             Content-Length:
                 - "569"
@@ -203,11 +203,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Link:
                 - </snapshots?page=1&per_page=50&name=named-snap-root&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -215,12 +215,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ae368503-ad57-44a6-84dc-9c012aa90876
+                - c0de98b4-c619-46f6-bcde-14178ba4badc
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 134.489098ms
+        duration: 151.189419ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -239,26 +239,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=packer-&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1011
-        body: '{"snapshots":[{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:40.233930Z", "references":[], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}, {"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:40.316749Z", "references":[], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}], "total_count":2}'
+        content_length: 1001
+        body: '{"snapshots":[{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:51.367728Z","references":[],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false},{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:51.438467Z","references":[],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}],"total_count":2}'
         headers:
             Content-Length:
-                - "1011"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -266,60 +266,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7e9f1957-3405-4a98-9b57-831b85a5d5e3
+                - 34d6a6fe-bf3c-44b9-8325-5c1f76eaa64f
         status: 200 OK
         code: 200
-        duration: 54.42503ms
+        duration: 83.248778ms
     - id: 6
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            include_deleted:
-                - "false"
-            name:
-                - named-snap-extra
-            order_by:
-                - created_at_asc
-            project_id:
-                - 19a4819b-24bf-4d44-969f-935ef0061b71
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=named-snap-extra&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 540
-        body: '{"snapshots":[{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:40.387862Z", "references":[], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}], "total_count":1}'
-        headers:
-            Content-Length:
-                - "540"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 959abbdd-34f5-48c5-a9bd-14441df26f00
-        status: 200 OK
-        code: 200
-        duration: 49.237785ms
-    - id: 7
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -337,26 +288,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=packer-&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1011
-        body: '{"snapshots":[{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:40.233930Z", "references":[], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}, {"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:40.316749Z", "references":[], "status":"in_use", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}], "total_count":2}'
+        content_length: 1001
+        body: '{"snapshots":[{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:51.367728Z","references":[],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false},{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:51.438467Z","references":[],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}],"total_count":2}'
         headers:
             Content-Length:
-                - "1011"
+                - "1001"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -364,10 +315,59 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 44843cc7-3713-4baf-8453-f3f9f381294a
+                - aca30a7d-21c3-4d85-a7ef-3dd27e5cbcf1
         status: 200 OK
         code: 200
-        duration: 48.629704ms
+        duration: 60.236157ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            include_deleted:
+                - "false"
+            name:
+                - named-snap-extra
+            order_by:
+                - created_at_asc
+            project_id:
+                - 19a4819b-24bf-4d44-969f-935ef0061b71
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=named-snap-extra&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 535
+        body: '{"snapshots":[{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:51.494646Z","references":[],"status":"in_use","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "535"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:53 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4bdbaabb-c94b-4a2d-8dfb-2617f9bb1053
+        status: 200 OK
+        code: 200
+        duration: 59.731358ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -382,28 +382,28 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes?name=Ubuntu&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 461
-        body: '{"volumes": [{"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": null, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:24:41.179424+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
+        content_length: 552
+        body: '{"volumes": [{"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:51.853239+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
         headers:
             Content-Length:
-                - "461"
+                - "552"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Link:
                 - </volumes?page=1&per_page=100&name=Ubuntu&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -411,12 +411,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 25378d7f-066a-4fe2-be00-7399c7f3ec8d
+                - 9a1ec613-715f-4c95-8f32-cba608d12d9d
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 88.73416ms
+        duration: 102.368507ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -435,26 +435,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=named-extra-volume&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 502
-        body: '{"volumes":[{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.533073Z", "updated_at":"2025-11-27T17:24:41.468297Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.468297Z", "zone":"nl-ams-1"}], "total_count":1}'
+        content_length: 705
+        body: '{"volumes":[{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.189554Z","updated_at":"2026-06-02T17:12:10.842021Z","references":[{"id":"755a3a97-b1c2-4ba2-b6b0-1fc904054e21","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.842021Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}],"total_count":1}'
         headers:
             Content-Length:
-                - "502"
+                - "705"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -462,10 +462,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b655706c-f429-4b1c-b7c8-86f6b82f2dd9
+                - 3dab221d-2f4a-4093-a0fc-433e089c5982
         status: 200 OK
         code: 200
-        duration: 83.229901ms
+        duration: 66.443183ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -484,26 +484,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=packer-&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1023
-        body: '{"volumes":[{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.678776Z", "updated_at":"2025-11-27T17:24:41.569005Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":15000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.569005Z", "zone":"nl-ams-1"}, {"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.809025Z", "updated_at":"2025-11-27T17:24:41.650720Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.650720Z", "zone":"nl-ams-1"}], "total_count":2}'
+        content_length: 1429
+        body: '{"volumes":[{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.301981Z","updated_at":"2026-06-02T17:12:10.920537Z","references":[{"id":"2eea7917-99fd-4f92-a330-584322ddc849","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.920537Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"},{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.453792Z","updated_at":"2026-06-02T17:12:10.998483Z","references":[{"id":"c31d4df0-284a-47a6-a98b-e7f7f15ae2e5","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.998483Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1023"
+                - "1429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -511,10 +511,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6b46badb-32a2-4fec-84ac-4f9428fbfea9
+                - 17644f46-df4a-4328-b49d-0726e41cc188
         status: 200 OK
         code: 200
-        duration: 56.921774ms
+        duration: 71.824737ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -533,26 +533,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=packer-&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1023
-        body: '{"volumes":[{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.678776Z", "updated_at":"2025-11-27T17:24:41.569005Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":15000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.569005Z", "zone":"nl-ams-1"}, {"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.809025Z", "updated_at":"2025-11-27T17:24:41.650720Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.650720Z", "zone":"nl-ams-1"}], "total_count":2}'
+        content_length: 1429
+        body: '{"volumes":[{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.301981Z","updated_at":"2026-06-02T17:12:10.920537Z","references":[{"id":"2eea7917-99fd-4f92-a330-584322ddc849","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.920537Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"},{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.453792Z","updated_at":"2026-06-02T17:12:10.998483Z","references":[{"id":"c31d4df0-284a-47a6-a98b-e7f7f15ae2e5","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.998483Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "1023"
+                - "1429"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:42 GMT
+                - Tue, 02 Jun 2026 17:13:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -560,11 +560,153 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f20ab7e5-a1c0-4710-bcb8-d22a98860fc8
+                - e309ae69-f400-4dc6-b021-e782c51f719e
         status: 200 OK
         code: 200
-        duration: 58.154658ms
+        duration: 74.855889ms
     - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - packer-tmp-server
+            order:
+                - creation_date_desc
+            project:
+                - 19a4819b-24bf-4d44-969f-935ef0061b71
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers?name=packer-tmp-server&order=creation_date_desc&project=19a4819b-24bf-4d44-969f-935ef0061b71
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3446
+        body: '{"servers": [{"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:51.853239+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:29.788213+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}]}'
+        headers:
+            Content-Length:
+                - "3446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:53 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=packer-tmp-server&order=creation_date_desc&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 74a893da-9b80-4f6d-b7d9-a0b8682f2a74
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 146.874631ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            name:
+                - packer-tmp-server
+            order:
+                - creation_date_desc
+            page:
+                - "1"
+            project:
+                - 19a4819b-24bf-4d44-969f-935ef0061b71
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers?name=packer-tmp-server&order=creation_date_desc&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 3446
+        body: '{"servers": [{"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:51.853239+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:29.788213+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}]}'
+        headers:
+            Content-Length:
+                - "3446"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:53 GMT
+            Link:
+                - </servers?page=1&per_page=50&name=packer-tmp-server&order=creation_date_desc&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 31d50d32-c84e-423a-9ba5-f3d898b9340d
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 150.810516ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - de4b9271-d925-409c-9b1a-b72ec3c84fc4
+        status: 204 No Content
+        code: 204
+        duration: 420.885764ms
+    - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -580,7 +722,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images?name=packer-e2e-complete&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -588,7 +730,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 956
-        body: '{"images": [{"id": "911efd53-5dce-4899-8c3f-84346acc192f", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"2": {"volume_type": "sbs_snapshot", "id": "f8cb373c-487f-4909-9a17-a29f3613ed28", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "size": 0, "name": ""}, "3": {"volume_type": "sbs_snapshot", "id": "8afe97a2-26c5-4567-84ad-5431f6eb8834", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:24:40.148524+00:00", "modification_date": "2025-11-27T17:24:40.148524+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
+        body: '{"images": [{"id": "6d100f83-b1ca-4374-97d0-56b353d26a12", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"3": {"volume_type": "sbs_snapshot", "id": "a22b5977-fd17-4b38-98c4-ca760ed91f3a", "size": 0, "name": ""}, "2": {"volume_type": "sbs_snapshot", "id": "11ae3867-02f7-472e-b966-43b397efc926", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T17:13:51.280221+00:00", "modification_date": "2026-06-02T17:13:51.280221+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
         headers:
             Content-Length:
                 - "956"
@@ -597,11 +739,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:43 GMT
+                - Tue, 02 Jun 2026 17:13:54 GMT
             Link:
                 - </images?page=1&per_page=50&name=packer-e2e-complete&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -609,13 +751,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c039123c-43c5-4d28-9424-fda4724d4cdf
+                - 4babeb5b-19db-48a0-9ef2-32ce2984669e
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 183.713859ms
-    - id: 13
+        duration: 187.349674ms
+    - id: 16
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -624,8 +766,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/911efd53-5dce-4899-8c3f-84346acc192f
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/6d100f83-b1ca-4374-97d0-56b353d26a12
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -639,9 +781,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:43 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -649,11 +791,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37aa7952-790b-406b-82bf-eab1685533e6
+                - d20ae747-2ead-4337-b3ce-16834c826ae8
         status: 204 No Content
         code: 204
-        duration: 484.787945ms
-    - id: 14
+        duration: 629.521109ms
+    - id: 17
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -669,7 +811,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots?name=named&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -677,7 +819,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 569
-        body: '{"snapshots": [{"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2025-11-27T17:24:23.714819+00:00", "modification_date": "2025-11-27T17:24:23.714819+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}]}'
+        body: '{"snapshots": [{"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2026-06-02T17:13:50.977152+00:00", "modification_date": "2026-06-02T17:13:50.977152+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}]}'
         headers:
             Content-Length:
                 - "569"
@@ -686,11 +828,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:43 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Link:
                 - </snapshots?page=1&per_page=50&name=named&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -698,13 +840,13 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - be5b596e-a27a-4199-8a8c-215d4249a762
+                - 571a24c6-9e4c-4efa-aec3-1eb75950db6e
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 139.555406ms
-    - id: 15
+        duration: 134.395505ms
+    - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -713,8 +855,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/8ad2f9c3-7802-45e3-ad45-6b56d65f4f59
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots/78b1d2a1-e607-498e-bc18-5317af6fdb11
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -728,9 +870,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:43 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -738,11 +880,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8d44f62a-f862-4417-9089-8b14529fcfd2
+                - a89d9a62-9b1d-4787-8aa0-91c96da421f0
         status: 204 No Content
         code: 204
-        duration: 134.195989ms
-    - id: 16
+        duration: 170.080296ms
+    - id: 19
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -758,28 +900,28 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes?name=Ubuntu&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 461
-        body: '{"volumes": [{"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": null, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:24:41.179424+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
+        content_length: 481
+        body: '{"volumes": [{"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": null, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:53.997965+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}]}'
         headers:
             Content-Length:
-                - "461"
+                - "481"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Link:
                 - </volumes?page=1&per_page=100&name=Ubuntu&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -787,139 +929,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 601293d4-2450-49ba-a5f7-ad4b7423b287
+                - 2ac045d1-fa21-4651-9388-2cf314fd1cfa
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 88.54765ms
-    - id: 17
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/d918e0be-6366-480f-bdb1-66a0a0e1aa89
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 5e5e2d86-0020-41df-8601-c393c7c9a67d
-        status: 204 No Content
-        code: 204
-        duration: 181.030013ms
-    - id: 18
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        form:
-            include_deleted:
-                - "false"
-            name:
-                - packer-
-            order_by:
-                - created_at_asc
-            page:
-                - "1"
-            project_id:
-                - 19a4819b-24bf-4d44-969f-935ef0061b71
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=packer-&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 1017
-        body: '{"snapshots":[{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:43.609831Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}, {"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"available"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:43.510042Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}], "total_count":2}'
-        headers:
-            Content-Length:
-                - "1017"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - d1ec3c43-f8d9-4b53-9432-1c516ccbaabe
-        status: 200 OK
-        code: 200
-        duration: 41.808103ms
-    - id: 19
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/e1d8c1b1-003e-4b92-8802-eb88ec7a86ac
-        method: DELETE
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 0
-        body: ""
-        headers:
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - dd88da1d-d802-423d-9b2c-f8b6702f6fe4
-        status: 204 No Content
-        code: 204
-        duration: 104.578481ms
+        duration: 107.597644ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -929,8 +944,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/f8cb373c-487f-4909-9a17-a29f3613ed28
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/052c733b-5561-4a91-9a83-4a81c8599ac6
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -944,9 +959,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -954,10 +969,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 8cecb94a-a040-4f67-a920-a3c3ef17b8e5
+                - aaded2e6-202e-435a-8e58-2ea82606eb74
         status: 204 No Content
         code: 204
-        duration: 103.082274ms
+        duration: 135.363887ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -978,26 +993,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=packer-&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=packer-&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 1023
-        body: '{"volumes":[{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.678776Z", "updated_at":"2025-11-27T17:24:41.569005Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":15000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.569005Z", "zone":"nl-ams-1"}, {"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.809025Z", "updated_at":"2025-11-27T17:24:41.650720Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.650720Z", "zone":"nl-ams-1"}], "total_count":2}'
+        content_length: 1013
+        body: '{"snapshots":[{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"available"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:55.253256Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false},{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"available"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:55.136196Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}],"total_count":2}'
         headers:
             Content-Length:
-                - "1023"
+                - "1013"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1005,10 +1020,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 705f0a1c-3907-4318-8515-0126e67807f6
+                - 36e43999-6346-49bd-af32-abdf4ba9eda5
         status: 200 OK
         code: 200
-        duration: 50.907948ms
+        duration: 51.270912ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -1018,8 +1033,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/42bd9c06-eeca-4538-ba34-66b70952ad89
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1033,9 +1048,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1043,10 +1058,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3a36d881-f2e2-4fe5-a299-10dd67939616
+                - 168417a7-97b5-4cd5-b5e0-872c6745cf12
         status: 204 No Content
         code: 204
-        duration: 90.973101ms
+        duration: 73.542179ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -1056,8 +1071,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/e16f0842-78c5-46aa-9a19-6318b759b4e1
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/11ae3867-02f7-472e-b966-43b397efc926
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1071,9 +1086,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1081,10 +1096,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19ecb5dc-0a5d-41ba-9733-c0a171516bad
+                - 4de49c33-d7d0-46ee-ac87-ed56b98e5b5d
         status: 204 No Content
         code: 204
-        duration: 99.650474ms
+        duration: 81.764506ms
     - id: 24
       request:
         proto: HTTP/1.1
@@ -1096,7 +1111,7 @@ interactions:
             include_deleted:
                 - "false"
             name:
-                - named
+                - packer-
             order_by:
                 - created_at_asc
             page:
@@ -1105,26 +1120,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=named&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=packer-&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 409
-        body: '{"snapshots":[{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":null, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:43.692310Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}], "total_count":1}'
+        content_length: 1025
+        body: '{"volumes":[{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.301981Z","updated_at":"2026-06-02T17:13:54.390829Z","references":[],"parent_snapshot_id":null,"status":"available","tags":["test","packer","complete"],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":"2026-06-02T17:13:54.390829Z","kms_key_id":null,"zone":"nl-ams-1"},{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.453792Z","updated_at":"2026-06-02T17:13:54.460554Z","references":[],"parent_snapshot_id":null,"status":"available","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2026-06-02T17:13:54.460554Z","kms_key_id":null,"zone":"nl-ams-1"}],"total_count":2}'
         headers:
             Content-Length:
-                - "409"
+                - "1025"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1132,10 +1147,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 7ec3aa61-fc3b-4bbd-af1e-dae692a15297
+                - 8eca543e-e2b2-43da-9a75-1d73fc3c47b1
         status: 200 OK
         code: 200
-        duration: 53.905634ms
+        duration: 48.565491ms
     - id: 25
       request:
         proto: HTTP/1.1
@@ -1145,8 +1160,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/8afe97a2-26c5-4567-84ad-5431f6eb8834
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/727e3666-764d-4e2f-bcb0-b4cb968c3333
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1160,9 +1175,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1170,11 +1185,49 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 17a11f9f-b49f-4eb0-9393-6a31ebf92bc8
+                - 40cb5fc3-bf69-4a62-a2d3-05f20131dcdd
         status: 204 No Content
         code: 204
-        duration: 91.999617ms
+        duration: 110.746076ms
     - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/e581e6ff-271c-4335-afa7-8388cc746a46
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e165d9cc-5409-4208-b872-e6628081e198
+        status: 204 No Content
+        code: 204
+        duration: 89.152925ms
+    - id: 27
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1194,26 +1247,26 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=named&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&name=named&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 502
-        body: '{"volumes":[{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.533073Z", "updated_at":"2025-11-27T17:24:41.468297Z", "references":[], "parent_snapshot_id":null, "status":"available", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:24:41.468297Z", "zone":"nl-ams-1"}], "total_count":1}'
+        content_length: 410
+        body: '{"snapshots":[{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":null,"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:54.987915Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}],"total_count":1}'
         headers:
             Content-Length:
-                - "502"
+                - "410"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1221,11 +1274,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2a0e8c48-92b7-4a18-91fe-b061d3e815b8
+                - 6ce57682-1fa7-4b37-80a5-b07a3bc54aff
         status: 200 OK
         code: 200
-        duration: 67.349883ms
-    - id: 27
+        duration: 58.33993ms
+    - id: 28
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1234,8 +1287,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/9939ac0a-5947-4850-8ebc-ece0b6b7f251
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/a22b5977-fd17-4b38-98c4-ca760ed91f3a
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1249,9 +1302,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:44 GMT
+                - Tue, 02 Jun 2026 17:13:56 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge02)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1259,7 +1312,96 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2ad52d8c-92d0-4645-ae33-fdebcd0bee04
+                - 52cc816b-171e-4615-b625-ec3d26de8771
         status: 204 No Content
         code: 204
-        duration: 81.68942ms
+        duration: 86.548667ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        form:
+            include_deleted:
+                - "false"
+            name:
+                - named
+            order_by:
+                - created_at_asc
+            page:
+                - "1"
+            project_id:
+                - 19a4819b-24bf-4d44-969f-935ef0061b71
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes?include_deleted=false&name=named&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 503
+        body: '{"volumes":[{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.189554Z","updated_at":"2026-06-02T17:13:54.271239Z","references":[],"parent_snapshot_id":null,"status":"available","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2026-06-02T17:13:54.271239Z","kms_key_id":null,"zone":"nl-ams-1"}],"total_count":1}'
+        headers:
+            Content-Length:
+                - "503"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4cf410f4-0014-4b76-a45f-a10a95dd0075
+        status: 200 OK
+        code: 200
+        duration: 54.860443ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/3a0cf77b-594e-4fdc-ad27-28408b7bebe8
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 0
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e74b0ef-c1cd-49f5-98b2-643c13a548fb
+        status: 204 No Content
+        code: 204
+        duration: 73.581312ms

--- a/internal/tests/testdata/packer-e2e-complete.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-complete.cassette.yaml
@@ -15,7 +15,7 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images?name=packer-e2e-complete&page=1
         method: GET
       response:
@@ -32,11 +32,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:18 GMT
+                - Tue, 02 Jun 2026 17:12:09 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-complete>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -44,12 +44,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ce565385-a5fc-4eca-b237-2361356bbe03
+                - 72a59dec-9a33-4131-bb43-337857f18a61
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 266.563655ms
+        duration: 282.488706ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -62,7 +62,7 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots?page=1
         method: GET
       response:
@@ -79,11 +79,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:18 GMT
+                - Tue, 02 Jun 2026 17:12:09 GMT
             Link:
                 - </snapshots?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -91,12 +91,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0c4fe9ea-3aa3-4380-a963-f20b4c92cea2
+                - 7c3736e7-0a49-4257-8ca6-f4aa161e3619
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 123.085464ms
+        duration: 131.773911ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,26 +113,26 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots?include_deleted=false&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 33
-        body: '{"snapshots":[], "total_count":0}'
+        content_length: 32
+        body: '{"snapshots":[],"total_count":0}'
         headers:
             Content-Length:
-                - "33"
+                - "32"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:18 GMT
+                - Tue, 02 Jun 2026 17:12:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -140,10 +140,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 37ded2d0-b84b-4440-bb9d-d7eafa22b40c
+                - dfa4f2bc-2a8b-46b4-bafb-2e733126a732
         status: 200 OK
         code: 200
-        duration: 66.671185ms
+        duration: 76.757311ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -156,26 +156,26 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 417
-        body: '{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.533073Z", "updated_at":"2025-11-27T17:23:19.533073Z", "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
+        content_length: 403
+        body: '{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.189554Z","updated_at":"2026-06-02T17:12:10.189554Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "417"
+                - "403"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:19 GMT
+                - Tue, 02 Jun 2026 17:12:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -183,10 +183,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4b1a3cd0-6aa0-4b85-88c4-0033377c96e6
+                - c5557315-3be6-4332-8f3a-af7f1075c577
         status: 200 OK
         code: 200
-        duration: 147.449543ms
+        duration: 123.119411ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -194,31 +194,31 @@ interactions:
         proto_minor: 1
         content_length: 170
         host: api.scaleway.com
-        body: '{"name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73","perf_iops":15000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":10000000000},"tags":null}'
+        body: '{"name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","perf_iops":15000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":10000000000},"tags":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 442
-        body: '{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.678776Z", "updated_at":"2025-11-27T17:23:19.678776Z", "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[], "specs":{"perf_iops":15000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
+        content_length: 428
+        body: '{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.301981Z","updated_at":"2026-06-02T17:12:10.301981Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "442"
+                - "428"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:19 GMT
+                - Tue, 02 Jun 2026 17:12:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -226,10 +226,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f6977f51-8106-4765-85c3-38196c4af8da
+                - 92fa7c91-51a0-4bea-909f-9503cac6cd04
         status: 200 OK
         code: 200
-        duration: 136.471802ms
+        duration: 130.483674ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -237,31 +237,31 @@ interactions:
         proto_minor: 1
         content_length: 169
         host: api.scaleway.com
-        body: '{"name":"packer-69288906-c998-23bf-62a4-802aa233c2cc","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":10000000000},"tags":null}'
+        body: '{"name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":10000000000},"tags":null}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1alpha1/zones/nl-ams-1/volumes
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 440
-        body: '{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.809025Z", "updated_at":"2025-11-27T17:23:19.809025Z", "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
+        content_length: 426
+        body: '{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.453792Z","updated_at":"2026-06-02T17:12:10.453792Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"nl-ams-1"}'
         headers:
             Content-Length:
-                - "440"
+                - "426"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:19 GMT
+                - Tue, 02 Jun 2026 17:12:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -269,44 +269,44 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f88f92af-30d8-491a-9e6f-3ac4cc38ac0d
+                - 66292410-7b0a-472d-8586-74f242724163
         status: 200 OK
         code: 200
-        duration: 127.091611ms
+        duration: 238.336884ms
     - id: 6
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 1214
+        content_length: 1216
         host: api.scaleway.com
-        body: '{"name":"packer-69288906-05d1-c9de-f183-64e6e70bca59","commercial_type":"DEV1-M","image":"ubuntu_jammy","volumes":{"0":{"size":12000000000,"volume_type":"l_ssd"},"1":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251","volume_type":"sbs_volume"},"2":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89","volume_type":"sbs_volume"},"3":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1","volume_type":"sbs_volume"}},"boot_type":"local","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="]}'
+        body: '{"name":"packer-tmp-server","commercial_type":"DEV1-M","image":"ubuntu_jammy","volumes":{"0":{"size":12000000000,"volume_type":"l_ssd"},"1":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","volume_type":"sbs_volume"},"2":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","volume_type":"sbs_volume"},"3":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","volume_type":"sbs_volume"}},"boot_type":"local","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["packer-build","tmp-server","AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3372
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3415
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3372"
+                - "3415"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:20 GMT
+                - Tue, 02 Jun 2026 17:12:11 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -314,10 +314,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ef89779e-2ce2-4c25-a13c-a52ddce8b301
+                - cea5c99b-819a-4932-bc75-395cb2be8578
         status: 201 Created
         code: 201
-        duration: 963.45963ms
+        duration: 975.532175ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -330,15 +330,15 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904/action
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0/action
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 357
-        body: '{"task": {"id": "f0fe2e06-4f17-4f5b-a056-732dfa30b255", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/3895e3c0-6bf5-4860-8109-950d96994904/action", "href_result": "/servers/3895e3c0-6bf5-4860-8109-950d96994904", "started_at": "2025-11-27T17:23:21.227074+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
+        body: '{"task": {"id": "c8f200d8-46be-42d4-857c-0b699976c7b8", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0/action", "href_result": "/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0", "started_at": "2026-06-02T17:12:12.020700+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -347,11 +347,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:21 GMT
+                - Tue, 02 Jun 2026 17:12:12 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/f0fe2e06-4f17-4f5b-a056-732dfa30b255
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/c8f200d8-46be-42d4-857c-0b699976c7b8
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -359,10 +359,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cec11bb-5422-4251-89d1-7333f3348f67
+                - a00fd78c-58f5-4343-b7a7-36af1f569816
         status: 202 Accepted
         code: 202
-        duration: 450.779768ms
+        duration: 509.001667ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -372,26 +372,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3394
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:20.860398+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3957
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:11.606404+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3394"
+                - "3957"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:21 GMT
+                - Tue, 02 Jun 2026 17:12:12 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -399,10 +399,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - bc21bd4b-e9af-4151-9dbd-b8fa04f8f3b0
+                - fb3fa2f7-6597-4dc6-836b-e00b08e49d60
         status: 200 OK
         code: 200
-        duration: 121.320141ms
+        duration: 122.133144ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -412,26 +412,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4020
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:20.860398+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4061
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:11.606404+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4020"
+                - "4061"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:26 GMT
+                - Tue, 02 Jun 2026 17:12:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -439,10 +439,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6732044-ede0-4d99-be8a-e07df308b3d1
+                - 4cde087c-3ed8-4c26-9135-ff6d7712c98e
         status: 200 OK
         code: 200
-        duration: 123.483812ms
+        duration: 148.30452ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -452,26 +452,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4020
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:20.860398+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4061
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:11.606404+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4020"
+                - "4061"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:31 GMT
+                - Tue, 02 Jun 2026 17:12:22 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -479,10 +479,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 19e63330-ece9-4aab-b6ab-57ab5580019e
+                - d198502a-e453-429f-9eab-d6ff55031858
         status: 200 OK
         code: 200
-        duration: 123.958223ms
+        duration: 157.485551ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -492,26 +492,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4020
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:20.860398+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4061
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "starting", "protected": false, "state_detail": "provisioning node", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:11.606404+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4020"
+                - "4061"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:36 GMT
+                - Tue, 02 Jun 2026 17:12:27 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -519,10 +519,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a47ad48-63e1-4d75-936a-4ef9ce6681e5
+                - 4ec4199a-2d84-4bfe-91a3-11c120f5f3cb
         status: 200 OK
         code: 200
-        duration: 109.383414ms
+        duration: 129.884315ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -532,26 +532,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4051
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:36.699696+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4092
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.178419+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4051"
+                - "4092"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:41 GMT
+                - Tue, 02 Jun 2026 17:12:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -559,10 +559,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a535ed19-23e2-4c57-b583-b04b4368d628
+                - 50ca24a7-2e73-4bd4-8555-8a7800e804ff
         status: 200 OK
         code: 200
-        duration: 137.168782ms
+        duration: 130.312861ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -572,26 +572,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4051
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:36.699696+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4092
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.178419+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4051"
+                - "4092"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:42 GMT
+                - Tue, 02 Jun 2026 17:12:32 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -599,10 +599,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fb855236-c6b8-435c-8375-6101ab2a7b86
+                - 03dcaf2f-b2f1-47ba-b26d-19de423ab6af
         status: 200 OK
         code: 200
-        duration: 121.242036ms
+        duration: 97.94576ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -615,15 +615,15 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904/action
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0/action
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 352
-        body: '{"task": {"id": "538f87f0-f4d4-4a4f-b969-d17a9019efc6", "description": "server_poweroff", "status": "pending", "href_from": "/servers/3895e3c0-6bf5-4860-8109-950d96994904/action", "href_result": "/servers/3895e3c0-6bf5-4860-8109-950d96994904", "started_at": "2025-11-27T17:23:42.421151+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
+        body: '{"task": {"id": "d082330f-18d1-4778-9bf3-bc53a7853f15", "description": "server_poweroff", "status": "pending", "href_from": "/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0/action", "href_result": "/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0", "started_at": "2026-06-02T17:12:33.128367+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -632,11 +632,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:42 GMT
+                - Tue, 02 Jun 2026 17:12:33 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/538f87f0-f4d4-4a4f-b969-d17a9019efc6
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/tasks/d082330f-18d1-4778-9bf3-bc53a7853f15
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -644,10 +644,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 4951d0e6-c9d5-4eab-8afd-ae850eeeecb2
+                - 60c2fbdd-ec30-4c9c-85e8-a267f8f8fb2b
         status: 202 Accepted
         code: 202
-        duration: 436.47969ms
+        duration: 295.504679ms
     - id: 15
       request:
         proto: HTTP/1.1
@@ -657,26 +657,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4011
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}, "public_ips": [{"id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4", "address": "51.15.102.253", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "43c51e26-36e0-48bc-a799-8fe4e9911dd4"}], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "4011"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:42 GMT
+                - Tue, 02 Jun 2026 17:12:33 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -684,10 +684,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 742e751e-ee7b-432d-b141-a2b7772434d7
+                - 2303e6f5-d1f4-47f4-9bc7-93598660b019
         status: 200 OK
         code: 200
-        duration: 121.567847ms
+        duration: 127.69228ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -697,26 +697,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:47 GMT
+                - Tue, 02 Jun 2026 17:12:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -724,10 +724,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b960472a-50dc-4c8b-80dc-20dc9521e6e2
+                - bda3fe9d-b1cc-45cb-8ecb-97d5962d95ec
         status: 200 OK
         code: 200
-        duration: 143.691903ms
+        duration: 162.81732ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -737,26 +737,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4054
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:52 GMT
+                - Tue, 02 Jun 2026 17:12:43 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -764,10 +764,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b7061adc-5bc5-4a6b-9796-d7ce368a90e6
+                - 6a80507e-1a8a-443d-80bc-da6932c6a372
         status: 200 OK
         code: 200
-        duration: 126.426747ms
+        duration: 133.171769ms
     - id: 18
       request:
         proto: HTTP/1.1
@@ -777,26 +777,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4054
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:23:57 GMT
+                - Tue, 02 Jun 2026 17:12:48 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -804,10 +804,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a73b3100-d1a1-440d-ae0c-8cc6f3b6e84e
+                - 322fbc90-7ef5-4793-9d6b-37f21714ead4
         status: 200 OK
         code: 200
-        duration: 124.97397ms
+        duration: 115.068522ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -817,26 +817,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4054
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:03 GMT
+                - Tue, 02 Jun 2026 17:12:53 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -844,10 +844,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f3d31d6-71ae-46a5-891b-331610125832
+                - 1d38e7d3-209a-4471-8574-473400bc5e2b
         status: 200 OK
         code: 200
-        duration: 138.632571ms
+        duration: 129.869225ms
     - id: 20
       request:
         proto: HTTP/1.1
@@ -857,26 +857,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4054
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:08 GMT
+                - Tue, 02 Jun 2026 17:12:58 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -884,10 +884,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 565f6563-9133-42a9-8609-efc3f4ea7101
+                - 896dafc0-5345-48c2-a064-bb984a2e4057
         status: 200 OK
         code: 200
-        duration: 125.329439ms
+        duration: 123.40805ms
     - id: 21
       request:
         proto: HTTP/1.1
@@ -897,26 +897,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4054
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4054"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:13 GMT
+                - Tue, 02 Jun 2026 17:13:04 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -924,10 +924,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - db997b98-3744-4f84-b74a-010c236a3af8
+                - cd194f6a-c9ec-400f-82a4-5f1072a2d944
         status: 200 OK
         code: 200
-        duration: 123.24045ms
+        duration: 131.561517ms
     - id: 22
       request:
         proto: HTTP/1.1
@@ -937,26 +937,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3489
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:42.061131+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "18", "hypervisor_id": "1802", "node_id": "11"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3489"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:18 GMT
+                - Tue, 02 Jun 2026 17:13:09 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -964,10 +964,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f23a3ddb-6c85-434f-80ee-230ada946d19
+                - 9457ce31-47f9-4641-acd8-84d7fa010c0a
         status: 200 OK
         code: 200
-        duration: 120.957746ms
+        duration: 127.484898ms
     - id: 23
       request:
         proto: HTTP/1.1
@@ -977,26 +977,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3372
-        body: '{"server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-69288906-05d1-c9de-f183-64e6e70bca59", "image": {"id": "f35eb2e8-a9cc-4b87-878c-68aec68e2cdf", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "bfa38aa1-d69a-4cf5-8461-f1c477249f86", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:14.656914+00:00", "modification_date": "2025-09-12T09:11:14.656914+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:23:19.962028+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "9939ac0a-5947-4850-8ebc-ece0b6b7f251", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "42bd9c06-eeca-4538-ba34-66b70952ad89", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e16f0842-78c5-46aa-9a19-6318b759b4e1", "state": "available", "zone": "nl-ams-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQCiZC0QAxroQ/HT1mOFFc5of8DAlH3nrYx24O8KzJbzZFzbo3j6VmwemiPJhkDv+bQX9o4MkQVID9L51wBwBEE6q2Dru2ZMURdqnD5M4tYP1OZ7fySCVlilZgZkboTji0YyL5rurUH9CThQLeMvje7X7avqjIfP8NiCAWMzH7QOoD+8u4AfBECoYrr0hv0a/5da+6XZXgjn+Ej4XJ/eRB0+9Kc9dufJUZ/eyAEVvtl5yCtEa9+Q9dYbUh27LjbbOqLkX5wyI85Lnpsz9X4T95GAKYIGnEU7ExDnR6yQq/f3j8QFOW0vJbyJPzTO+YSbLqYBLCZ/Lzdd/9MBLeYBZ3HJ/o65m395gLurqkgDfx1F/47zcClbcFvIaGMT9oC/Vs7J/imowkeQi4HhqcHNzHYHeMO1f7t7NkYmmm4nIqJba1rbylPi3HIJOHZULirtOoJ5BN1vO4X26YP9aDMaKO0HqHcvk8NuZ7sBQTeU2m/CBtmBDvIpSlt9ZfzEgrEUyE7JCwb/JN9AXTIFhTwWRXEGlIN3ZBfoRkheXm9g/CqyXgxss0fHrD2Zv4t68wH7QZZybu56ASKatqAva8Y9Y0y+tOYNpyEESQ8crG0ZOeS+IDG0h/Ex5C6ek+I9zu0f6GNitfWUsvrHVQICZ/PjF3ca99cBrANiUGxkhlVGSyOPSQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:60:65:55", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:24:21.142505+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3372"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:23 GMT
+                - Tue, 02 Jun 2026 17:13:14 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1004,42 +1004,39 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d767106c-87b5-4489-a4e2-5752a9e45f3f
+                - 284093f5-91f4-4ebf-b719-b59ce83e3962
         status: 200 OK
         code: 200
-        duration: 110.039789ms
+        duration: 144.292968ms
     - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 193
+        content_length: 0
         host: api.scaleway.com
-        body: '{"name":"named-snap-root-volume-0","volume_id":"d918e0be-6366-480f-bdb1-66a0a0e1aa89","tags":["test","packer","complete"],"project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 877
-        body: '{"snapshot": {"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2025-11-27T17:24:23.714819+00:00", "modification_date": "2025-11-27T17:24:23.714819+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}, "task": {"id": "4906799f-21c0-4eaf-97a1-306b8f4df4f2", "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "started_at": "2025-11-27T17:24:23.931899+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "877"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:23 GMT
+                - Tue, 02 Jun 2026 17:13:19 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1047,42 +1044,39 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b2a72006-231c-4057-a80a-6b54f834a6bf
-        status: 201 Created
-        code: 201
-        duration: 348.514174ms
+                - af2c6c91-b3c9-459e-8bcc-dad2732fb3d4
+        status: 200 OK
+        code: 200
+        duration: 124.404132ms
     - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 167
+        content_length: 0
         host: api.scaleway.com
-        body: '{"volume_id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251","name":"packer-1764264198","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots
-        method: POST
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 475
-        body: '{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:24.095275Z", "references":[], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "475"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:24 GMT
+                - Tue, 02 Jun 2026 17:13:24 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1090,10 +1084,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0df7ec34-831f-4e4b-88d8-df96acb8ebda
+                - 778ff8bf-07fc-4862-a88c-2703242d66f1
         status: 200 OK
         code: 200
-        duration: 175.227864ms
+        duration: 145.710934ms
     - id: 26
       request:
         proto: HTTP/1.1
@@ -1103,26 +1097,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/e1d8c1b1-003e-4b92-8802-eb88ec7a86ac
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 706
-        body: '{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:24.095275Z", "references":[{"id":"da6219f2-fb8c-49f8-989d-1cbe0e5ab488", "product_resource_type":"internal", "product_resource_id":"00000000-0000-0000-0000-000000000000", "created_at":"2025-11-27T17:24:24.142801Z", "type":"unknown_type", "status":"attached"}], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 4052
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}, "public_ips": [{"id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18", "address": "51.15.93.202", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "1345cf6f-1a99-4d43-a7cf-796babc9fc18"}], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:32.923606+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": {"zone_id": "nl-ams-1", "platform_id": "23", "cluster_id": "17", "hypervisor_id": "1702", "node_id": "26"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "706"
+                - "4052"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:24 GMT
+                - Tue, 02 Jun 2026 17:13:29 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1130,10 +1124,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a4fec52f-8d15-435c-a3a2-a5e6e9bf6c89
+                - 2e97dca1-8f25-42ae-9bb0-e421c0e78bbb
         status: 200 OK
         code: 200
-        duration: 103.267431ms
+        duration: 144.407943ms
     - id: 27
       request:
         proto: HTTP/1.1
@@ -1143,26 +1137,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/e1d8c1b1-003e-4b92-8802-eb88ec7a86ac
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/718e4d45-81e6-444c-aaaf-f4c0324a48c0
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 476
-        body: '{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "name":"packer-1764264198", "parent_volume":{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:24.095275Z", "updated_at":"2025-11-27T17:24:24.095275Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 3415
+        body: '{"server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server", "arch": "x86_64", "commercial_type": "DEV1-M", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-tmp-server", "image": {"id": "301c3494-3fa8-4a35-aaf7-13acd617a0a4", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "79effaea-adab-4399-985f-89811062d7c7", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:05:47.058619+00:00", "modification_date": "2026-05-12T15:05:47.058619+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "nl-ams-1"}, "volumes": {"0": {"boot": false, "id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:12:10.756055+00:00", "tags": [], "zone": "nl-ams-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "3a0cf77b-594e-4fdc-ad27-28408b7bebe8", "state": "available", "zone": "nl-ams-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id": "727e3666-764d-4e2f-bcb0-b4cb968c3333", "state": "available", "zone": "nl-ams-1"}, "3": {"boot": false, "volume_type": "sbs_volume", "id": "e581e6ff-271c-4335-afa7-8388cc746a46", "state": "available", "zone": "nl-ams-1"}}, "tags": ["packer-build", "tmp-server", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDA3q1lnR7+5xjXTL0EyIH6D5fYz+1MgdFkyQfUbXK/xMF3ll8CA8rS5DdhwsArfo7vabaazndRtkuc6G0Tk1Abx5vrNdbR5NN/0UFe00VN+wsw21DLxRxmj5hMrfNG0JMCuINz8WgP/IUgrJ78fuJ+r29MjLW0vzR8+dGLis79as7YaGYpA63XLz84ClMPmK/7HOET3JELWgYGFSDceIPeHX9rZts6G4VhJhbPotMgcjfx6Dwvd6aPEziNmPssa6tWJm4hUav+DB/kItqpQb7QZHcb5S3tvsf74xoaEuXtyzHdRd/fHx8xzFl2hDs5paP7r+xFva7nu03/g/XJz0wl3alvbqnnXo+ljGwLK5W7LDdd6JWHpoFBVETKAbymKJ5RnOM0o0kzDChzI/6UcqeQPFl6rSungoo2CpusTV3oAF2OvXxsD8IDLlSvEheC7wT++ATWuMKil6nD/Wbn/faO1jm41NpawFkUniMz1Y7zKCR8YRDNAh3n5SFwbKZ+lhBMbx9vlCtVhf2c3sL722F9kx8YCKFGZOocc98OoN5eq3QZ2+uLMTphfgoUjocG7TjaX6EJV0AwcfJEnou8IuNooENF7UdXziAR7PmECCopun11KD2OvN8oaPfmUQIHFtTtT1FnGgJRDsTOkeGOWBuYFi4uxfCgxqSGDF5oUJH/Mw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:6a:a1:e5", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:29.788213+00:00", "bootscript": null, "security_group": {"id": "12bbbb33-d266-44fc-9616-f009b6468a83", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "nl-ams-1", "filesystems": [], "end_of_service": false, "dns": "718e4d45-81e6-444c-aaaf-f4c0324a48c0.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "476"
+                - "3415"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:29 GMT
+                - Tue, 02 Jun 2026 17:13:34 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1170,10 +1164,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b76cf86b-e565-42aa-8b58-141002e7cee0
+                - 2520abe2-4dcb-4b70-bd9b-9617ca5eabec
         status: 200 OK
         code: 200
-        duration: 83.808768ms
+        duration: 157.54622ms
     - id: 28
       request:
         proto: HTTP/1.1
@@ -1181,31 +1175,31 @@ interactions:
         proto_minor: 1
         content_length: 167
         host: api.scaleway.com
-        body: '{"volume_id":"42bd9c06-eeca-4538-ba34-66b70952ad89","name":"packer-1764264198","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
+        body: '{"volume_id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"packer-1780420329","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 499
-        body: '{"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:29.447409Z", "references":[], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 474
+        body: '{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:35.111445Z","references":[],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "499"
+                - "474"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:29 GMT
+                - Tue, 02 Jun 2026 17:13:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1213,10 +1207,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e4555027-dafa-4d0e-a7d4-a7a90df06f24
+                - e5d1f5eb-344a-47c5-af83-aef800f8eeca
         status: 200 OK
         code: 200
-        duration: 172.014645ms
+        duration: 162.063115ms
     - id: 29
       request:
         proto: HTTP/1.1
@@ -1226,26 +1220,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/f8cb373c-487f-4909-9a17-a29f3613ed28
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 730
-        body: '{"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:29.447409Z", "references":[{"id":"f9ff9b7b-b1e3-4bf7-addc-2c06956f4755", "product_resource_type":"internal", "product_resource_id":"00000000-0000-0000-0000-000000000000", "created_at":"2025-11-27T17:24:29.501092Z", "type":"unknown_type", "status":"attached"}], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 700
+        body: '{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:35.111445Z","references":[{"id":"bc68f2fb-d74d-4ffb-8b60-d966ca07f297","product_resource_type":"internal","product_resource_id":"00000000-0000-0000-0000-000000000000","created_at":"2026-06-02T17:13:35.162339Z","type":"unknown_type","status":"attached"}],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "730"
+                - "700"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:29 GMT
+                - Tue, 02 Jun 2026 17:13:35 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1253,10 +1247,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 317b65f8-2504-423f-a4b4-38d626af7532
+                - 727d667b-a1b5-44b9-a32a-90069cf1c5c0
         status: 200 OK
         code: 200
-        duration: 84.32748ms
+        duration: 65.772542ms
     - id: 30
       request:
         proto: HTTP/1.1
@@ -1266,26 +1260,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/f8cb373c-487f-4909-9a17-a29f3613ed28
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 500
-        body: '{"id":"f8cb373c-487f-4909-9a17-a29f3613ed28", "name":"packer-1764264198", "parent_volume":{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:29.447409Z", "updated_at":"2025-11-27T17:24:29.447409Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 475
+        body: '{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23","name":"packer-1780420329","parent_volume":{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:35.111445Z","updated_at":"2026-06-02T17:13:35.111445Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "500"
+                - "475"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:34 GMT
+                - Tue, 02 Jun 2026 17:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1293,42 +1287,42 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f00da4cc-a509-4779-8d97-3452be90832c
+                - 5bc00407-2a2c-4943-84de-7e9d46ea7851
         status: 200 OK
         code: 200
-        duration: 81.240888ms
+        duration: 67.836134ms
     - id: 31
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 175
+        content_length: 167
         host: api.scaleway.com
-        body: '{"volume_id":"e16f0842-78c5-46aa-9a19-6318b759b4e1","name":"named-snap-extra-volume-3","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
+        body: '{"volume_id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-1780420329","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 506
-        body: '{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:34.799449Z", "references":[], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 498
+        body: '{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:40.415809Z","references":[],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "506"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:34 GMT
+                - Tue, 02 Jun 2026 17:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1336,10 +1330,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 54537115-f360-444a-991f-18cc5a2298de
+                - 223e39a6-e4e2-476a-b84e-7dc762a31f50
         status: 200 OK
         code: 200
-        duration: 183.690394ms
+        duration: 168.623026ms
     - id: 32
       request:
         proto: HTTP/1.1
@@ -1349,26 +1343,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/8afe97a2-26c5-4567-84ad-5431f6eb8834
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/11ae3867-02f7-472e-b966-43b397efc926
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 737
-        body: '{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:34.799449Z", "references":[{"id":"338a6c8e-b68b-441d-a836-f3d35d4258c7", "product_resource_type":"internal", "product_resource_id":"00000000-0000-0000-0000-000000000000", "created_at":"2025-11-27T17:24:34.853321Z", "type":"unknown_type", "status":"attached"}], "status":"creating", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 724
+        body: '{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:40.415809Z","references":[{"id":"ea9c29cd-8ce0-44d8-b43d-b3d189a5141c","product_resource_type":"internal","product_resource_id":"00000000-0000-0000-0000-000000000000","created_at":"2026-06-02T17:13:40.462254Z","type":"unknown_type","status":"attached"}],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "737"
+                - "724"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:34 GMT
+                - Tue, 02 Jun 2026 17:13:40 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1376,10 +1370,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 860ac6f9-39a0-4e48-9101-07dc9b4de7e1
+                - 90f2aab4-4568-4787-9ef7-1b29887d4a64
         status: 200 OK
         code: 200
-        duration: 84.219989ms
+        duration: 70.698098ms
     - id: 33
       request:
         proto: HTTP/1.1
@@ -1389,26 +1383,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/8afe97a2-26c5-4567-84ad-5431f6eb8834
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/11ae3867-02f7-472e-b966-43b397efc926
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 507
-        body: '{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834", "name":"named-snap-extra-volume-3", "parent_volume":{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:24:34.799449Z", "updated_at":"2025-11-27T17:24:34.799449Z", "references":[], "status":"available", "tags":["test", "packer", "complete"], "class":"sbs", "zone":"nl-ams-1"}'
+        content_length: 499
+        body: '{"id":"11ae3867-02f7-472e-b966-43b397efc926","name":"packer-1780420329","parent_volume":{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:40.415809Z","updated_at":"2026-06-02T17:13:40.415809Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "507"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
+                - Tue, 02 Jun 2026 17:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1416,44 +1410,42 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fe491edc-b7a6-4924-a537-d893034ab1aa
+                - 46fcd4b9-cbe4-4669-8443-daa21c3ed0f7
         status: 200 OK
         code: 200
-        duration: 89.611756ms
+        duration: 77.915395ms
     - id: 34
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 367
+        content_length: 175
         host: api.scaleway.com
-        body: '{"name":"packer-e2e-complete","root_volume":"8ad2f9c3-7802-45e3-ad45-6b56d65f4f59","arch":"x86_64","extra_volumes":{"1":{"id":"e1d8c1b1-003e-4b92-8802-eb88ec7a86ac"},"2":{"id":"f8cb373c-487f-4909-9a17-a29f3613ed28"},"3":{"id":"8afe97a2-26c5-4567-84ad-5431f6eb8834"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"],"public":false}'
+        body: '{"volume_id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"named-snap-extra-volume-3","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 953
-        body: '{"image": {"id": "911efd53-5dce-4899-8c3f-84346acc192f", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"2": {"volume_type": "sbs_snapshot", "id": "f8cb373c-487f-4909-9a17-a29f3613ed28", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "size": 0, "name": ""}, "3": {"volume_type": "sbs_snapshot", "id": "8afe97a2-26c5-4567-84ad-5431f6eb8834", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:24:40.148524+00:00", "modification_date": "2025-11-27T17:24:40.148524+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
+        content_length: 505
+        body: '{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:45.736500Z","references":[],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
         headers:
             Content-Length:
-                - "953"
+                - "505"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/911efd53-5dce-4899-8c3f-84346acc192f
+                - Tue, 02 Jun 2026 17:13:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1461,10 +1453,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 2f2e2789-1a19-4f4a-b408-4ad4d3815319
-        status: 201 Created
-        code: 201
-        duration: 529.758852ms
+                - 19469a85-58a2-4707-9d6e-ec58aefafc99
+        status: 200 OK
+        code: 200
+        duration: 164.554852ms
     - id: 35
       request:
         proto: HTTP/1.1
@@ -1474,15 +1466,141 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/911efd53-5dce-4899-8c3f-84346acc192f
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/a22b5977-fd17-4b38-98c4-ca760ed91f3a
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
+        content_length: 731
+        body: '{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:45.736500Z","references":[{"id":"66224973-babf-433b-a7dd-016e514ff600","product_resource_type":"internal","product_resource_id":"00000000-0000-0000-0000-000000000000","created_at":"2026-06-02T17:13:45.781774Z","type":"unknown_type","status":"attached"}],"status":"creating","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
+        headers:
+            Content-Length:
+                - "731"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - edc32ac4-4303-445e-8db5-2baa3e389b69
+        status: 200 OK
+        code: 200
+        duration: 52.639376ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.scaleway.com
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/snapshots/a22b5977-fd17-4b38-98c4-ca760ed91f3a
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 506
+        body: '{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a","name":"named-snap-extra-volume-3","parent_volume":{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:13:45.736500Z","updated_at":"2026-06-02T17:13:45.736500Z","references":[],"status":"available","tags":["test","packer","complete"],"class":"sbs","zone":"nl-ams-1","public":false}'
+        headers:
+            Content-Length:
+                - "506"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 89c954c1-b5af-42c1-a79d-aeea0a0dfeb9
+        status: 200 OK
+        code: 200
+        duration: 55.879943ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 193
+        host: api.scaleway.com
+        body: '{"name":"named-snap-root-volume-0","volume_id":"052c733b-5561-4a91-9a83-4a81c8599ac6","tags":["test","packer","complete"],"project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/snapshots
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 877
+        body: '{"snapshot": {"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "creation_date": "2026-06-02T17:13:50.977152+00:00", "modification_date": "2026-06-02T17:13:50.977152+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 12000000000, "state": "available", "base_volume": {"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["test", "packer", "complete"], "zone": "nl-ams-1", "error_details": null}, "task": {"id": "cd77b81f-2c3e-4d63-a950-76b54329ccfb", "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/78b1d2a1-e607-498e-bc18-5317af6fdb11", "started_at": "2026-06-02T17:13:51.136164+00:00", "terminated_at": null, "progress": 0, "zone": "nl-ams-1"}}'
+        headers:
+            Content-Length:
+                - "877"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:51 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ced89645-3426-4bc5-a657-b12b2e07162f
+        status: 201 Created
+        code: 201
+        duration: 282.409942ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 367
+        host: api.scaleway.com
+        body: '{"name":"packer-e2e-complete","root_volume":"78b1d2a1-e607-498e-bc18-5317af6fdb11","arch":"x86_64","extra_volumes":{"1":{"id":"c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23"},"2":{"id":"11ae3867-02f7-472e-b966-43b397efc926"},"3":{"id":"a22b5977-fd17-4b38-98c4-ca760ed91f3a"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["test","packer","complete"],"public":false}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
         content_length: 953
-        body: '{"image": {"id": "911efd53-5dce-4899-8c3f-84346acc192f", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "8ad2f9c3-7802-45e3-ad45-6b56d65f4f59", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"2": {"volume_type": "sbs_snapshot", "id": "f8cb373c-487f-4909-9a17-a29f3613ed28", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "e1d8c1b1-003e-4b92-8802-eb88ec7a86ac", "size": 0, "name": ""}, "3": {"volume_type": "sbs_snapshot", "id": "8afe97a2-26c5-4567-84ad-5431f6eb8834", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:24:40.148524+00:00", "modification_date": "2025-11-27T17:24:40.148524+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
+        body: '{"image": {"id": "6d100f83-b1ca-4374-97d0-56b353d26a12", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"3": {"volume_type": "sbs_snapshot", "id": "a22b5977-fd17-4b38-98c4-ca760ed91f3a", "size": 0, "name": ""}, "2": {"volume_type": "sbs_snapshot", "id": "11ae3867-02f7-472e-b966-43b397efc926", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T17:13:51.280221+00:00", "modification_date": "2026-06-02T17:13:51.280221+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
         headers:
             Content-Length:
                 - "953"
@@ -1491,9 +1609,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
+                - Tue, 02 Jun 2026 17:13:51 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/6d100f83-b1ca-4374-97d0-56b353d26a12
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1501,171 +1621,39 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa538432-25d0-4089-af93-2402eca0974f
-        status: 200 OK
-        code: 200
-        duration: 126.429205ms
-    - id: 36
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 37
-        host: api.scaleway.com
-        body: '{"tags":["test","packer","complete"]}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/d918e0be-6366-480f-bdb1-66a0a0e1aa89
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 127
-        body: '{"message":"resource is not found","resource":"volume","resource_id":"d918e0be-6366-480f-bdb1-66a0a0e1aa89","type":"not_found"}'
-        headers:
-            Content-Length:
-                - "127"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 69ff43aa-54f9-45af-8131-dd287b57e340
-        status: 404 Not Found
-        code: 404
-        duration: 40.508514ms
-    - id: 37
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 37
-        host: api.scaleway.com
-        body: '{"tags":["test","packer","complete"]}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/d918e0be-6366-480f-bdb1-66a0a0e1aa89
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 555
-        body: '{"volume": {"id": "d918e0be-6366-480f-bdb1-66a0a0e1aa89", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "3895e3c0-6bf5-4860-8109-950d96994904", "name": "packer-69288906-05d1-c9de-f183-64e6e70bca59"}, "size": 12000000000, "state": "available", "creation_date": "2025-11-27T17:23:19.962028+00:00", "modification_date": "2025-11-27T17:24:40.793711+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
-        headers:
-            Content-Length:
-                - "555"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6120cfa8-cbd1-43fc-bcbd-c7f793126c75
-        status: 200 OK
-        code: 200
-        duration: 116.864716ms
-    - id: 38
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 37
-        host: api.scaleway.com
-        body: '{"tags":["test","packer","complete"]}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/9939ac0a-5947-4850-8ebc-ece0b6b7f251
-        method: PATCH
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 678
-        body: '{"id":"9939ac0a-5947-4850-8ebc-ece0b6b7f251", "name":"named-extra-volume-1", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.533073Z", "updated_at":"2025-11-27T17:23:20.084525Z", "references":[{"id":"b2316a45-3e51-49a4-8b41-114f56d6c2b1", "product_resource_type":"instance_server", "product_resource_id":"3895e3c0-6bf5-4860-8109-950d96994904", "created_at":"2025-11-27T17:23:20.084525Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
-        headers:
-            Content-Length:
-                - "678"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:24:40 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6d172342-50d1-4cc4-be9c-6b6c5ab94386
-        status: 200 OK
-        code: 200
-        duration: 81.042156ms
+                - 9347832f-06b0-426e-adf5-5d2ed16c4db6
+        status: 201 Created
+        code: 201
+        duration: 452.547396ms
     - id: 39
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 37
+        content_length: 0
         host: api.scaleway.com
-        body: '{"tags":["test","packer","complete"]}'
         headers:
-            Content-Type:
-                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/42bd9c06-eeca-4538-ba34-66b70952ad89
-        method: PATCH
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/images/6d100f83-b1ca-4374-97d0-56b353d26a12
+        method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 703
-        body: '{"id":"42bd9c06-eeca-4538-ba34-66b70952ad89", "name":"packer-69288906-3ad2-c23e-9a59-6fcf82029d73", "type":"sbs_15k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.678776Z", "updated_at":"2025-11-27T17:23:20.154558Z", "references":[{"id":"af22cf76-16af-487d-8a1d-1455f319fd75", "product_resource_type":"instance_server", "product_resource_id":"3895e3c0-6bf5-4860-8109-950d96994904", "created_at":"2025-11-27T17:23:20.154558Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use", "tags":["test", "packer", "complete"], "specs":{"perf_iops":15000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
+        content_length: 953
+        body: '{"image": {"id": "6d100f83-b1ca-4374-97d0-56b353d26a12", "name": "packer-e2e-complete", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"id": "78b1d2a1-e607-498e-bc18-5317af6fdb11", "name": "named-snap-root-volume-0", "volume_type": "l_ssd", "size": 12000000000}, "extra_volumes": {"3": {"volume_type": "sbs_snapshot", "id": "a22b5977-fd17-4b38-98c4-ca760ed91f3a", "size": 0, "name": ""}, "2": {"volume_type": "sbs_snapshot", "id": "11ae3867-02f7-472e-b966-43b397efc926", "size": 0, "name": ""}, "1": {"volume_type": "sbs_snapshot", "id": "c3cf2146-4a3a-46f5-83f6-d1fb58ef4c23", "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T17:13:51.280221+00:00", "modification_date": "2026-06-02T17:13:51.280221+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
         headers:
             Content-Length:
-                - "703"
+                - "953"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:41 GMT
+                - Tue, 02 Jun 2026 17:13:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1673,10 +1661,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0a7dc94d-d3a9-4d50-91bd-53427450f03b
+                - 8a2b3ab9-601c-46ab-8585-d75e522d8c1a
         status: 200 OK
         code: 200
-        duration: 109.983032ms
+        duration: 132.050344ms
     - id: 40
       request:
         proto: HTTP/1.1
@@ -1689,26 +1677,26 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/e16f0842-78c5-46aa-9a19-6318b759b4e1
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/052c733b-5561-4a91-9a83-4a81c8599ac6
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 701
-        body: '{"id":"e16f0842-78c5-46aa-9a19-6318b759b4e1", "name":"packer-69288906-c998-23bf-62a4-802aa233c2cc", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:23:19.809025Z", "updated_at":"2025-11-27T17:23:20.231629Z", "references":[{"id":"7f568101-3cb2-4530-943c-ad5e9c23cb0a", "product_resource_type":"instance_server", "product_resource_id":"3895e3c0-6bf5-4860-8109-950d96994904", "created_at":"2025-11-27T17:23:20.231629Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use", "tags":["test", "packer", "complete"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"nl-ams-1"}'
+        content_length: 127
+        body: '{"message":"resource is not found","resource":"volume","resource_id":"052c733b-5561-4a91-9a83-4a81c8599ac6","type":"not_found"}'
         headers:
             Content-Length:
-                - "701"
+                - "127"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:41 GMT
+                - Tue, 02 Jun 2026 17:13:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1716,37 +1704,42 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - eda96bb3-38bf-40e6-9385-8a6e04baa9ee
-        status: 200 OK
-        code: 200
-        duration: 75.482562ms
+                - a8e8fd26-40bd-4d22-882c-2b6230fe123f
+        status: 404 Not Found
+        code: 404
+        duration: 46.176587ms
     - id: 41
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 37
         host: api.scaleway.com
+        body: '{"tags":["test","packer","complete"]}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/servers/3895e3c0-6bf5-4860-8109-950d96994904
-        method: DELETE
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/nl-ams-1/volumes/052c733b-5561-4a91-9a83-4a81c8599ac6
+        method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 0
-        body: ""
+        content_length: 549
+        body: '{"volume": {"id": "052c733b-5561-4a91-9a83-4a81c8599ac6", "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "server": {"id": "718e4d45-81e6-444c-aaaf-f4c0324a48c0", "name": "packer-tmp-server"}, "size": 12000000000, "state": "available", "creation_date": "2026-06-02T17:12:10.756055+00:00", "modification_date": "2026-06-02T17:13:51.853239+00:00", "tags": ["test", "packer", "complete"], "zone": "nl-ams-1"}}'
         headers:
+            Content-Length:
+                - "549"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:24:41 GMT
+                - Tue, 02 Jun 2026 17:13:51 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge03)
+                - Scaleway API Gateway (fr-par-2;edge01)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1754,7 +1747,136 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ddd3f0d7-b365-44b5-b2ae-40566237d4a2
-        status: 204 No Content
-        code: 204
-        duration: 447.747648ms
+                - 5183e672-95f3-4ddf-ba34-13d9aa245de0
+        status: 200 OK
+        code: 200
+        duration: 123.94133ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 37
+        host: api.scaleway.com
+        body: '{"tags":["test","packer","complete"]}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/3a0cf77b-594e-4fdc-ad27-28408b7bebe8
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 675
+        body: '{"id":"3a0cf77b-594e-4fdc-ad27-28408b7bebe8","name":"named-extra-volume-1","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.189554Z","updated_at":"2026-06-02T17:12:10.842021Z","references":[{"id":"755a3a97-b1c2-4ba2-b6b0-1fc904054e21","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.842021Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}'
+        headers:
+            Content-Length:
+                - "675"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 562c7338-072c-4fcf-ba77-f3adeb3a033f
+        status: 200 OK
+        code: 200
+        duration: 88.993155ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 37
+        host: api.scaleway.com
+        body: '{"tags":["test","packer","complete"]}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/727e3666-764d-4e2f-bcb0-b4cb968c3333
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 700
+        body: '{"id":"727e3666-764d-4e2f-bcb0-b4cb968c3333","name":"packer-6a1f0ee9-b364-8c98-5775-f8cb0702c7ec","type":"sbs_15k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.301981Z","updated_at":"2026-06-02T17:12:10.920537Z","references":[{"id":"2eea7917-99fd-4f92-a330-584322ddc849","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.920537Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}'
+        headers:
+            Content-Length:
+                - "700"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 15d838a6-7007-4d0e-86af-99c0d3d49c9b
+        status: 200 OK
+        code: 200
+        duration: 96.16176ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 37
+        host: api.scaleway.com
+        body: '{"tags":["test","packer","complete"]}'
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/nl-ams-1/volumes/e581e6ff-271c-4335-afa7-8388cc746a46
+        method: PATCH
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 698
+        body: '{"id":"e581e6ff-271c-4335-afa7-8388cc746a46","name":"packer-6a1f0ee9-1498-c81d-b472-6adda1177e47","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T17:12:10.453792Z","updated_at":"2026-06-02T17:12:10.998483Z","references":[{"id":"c31d4df0-284a-47a6-a98b-e7f7f15ae2e5","product_resource_type":"instance_server","product_resource_id":"718e4d45-81e6-444c-aaaf-f4c0324a48c0","created_at":"2026-06-02T17:12:10.998483Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":["test","packer","complete"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"nl-ams-1"}'
+        headers:
+            Content-Length:
+                - "698"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Tue, 02 Jun 2026 17:13:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4642a550-cdea-45fe-92ba-e84412a0d624
+        status: 200 OK
+        code: 200
+        duration: 97.158965ms

--- a/internal/tests/testdata/packer-e2e-simple.cassette.yaml
+++ b/internal/tests/testdata/packer-e2e-simple.cassette.yaml
@@ -15,7 +15,7 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1
         method: GET
       response:
@@ -32,11 +32,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:16 GMT
+                - Tue, 02 Jun 2026 16:18:38 GMT
             Link:
                 - </images?page=0&per_page=50&name=packer-e2e-simple>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -44,12 +44,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f3cd85fb-c6f5-414a-95be-5797fe0e2692
+                - ebc22422-69f5-4bc4-ab69-db4529a141f4
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 375.237439ms
+        duration: 359.457871ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -62,28 +62,28 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots?page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 470
-        body: '{"snapshots": [{"id": "040de054-2855-426c-a8db-f224be7f2058", "name": "packer-e2e-root-volume-local_snap_0", "volume_type": "l_ssd", "creation_date": "2025-11-12T14:23:01.653225+00:00", "modification_date": "2025-11-12T14:32:10.634612+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state": "available", "base_volume": null, "tags": [], "zone": "fr-par-1", "error_details": null}]}'
+        content_length: 17
+        body: '{"snapshots": []}'
         headers:
             Content-Length:
-                - "470"
+                - "17"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:16 GMT
+                - Tue, 02 Jun 2026 16:18:38 GMT
             Link:
-                - </snapshots?page=1&per_page=50&>; rel="last"
+                - </snapshots?page=0&per_page=50&>; rel="last"
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -91,12 +91,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - aa7c9d69-7db7-4a7e-a7e1-ca6a583fe41a
+                - e4d31b47-c801-43be-8230-34c16b505c1f
             X-Total-Count:
-                - "1"
+                - "0"
         status: 200 OK
         code: 200
-        duration: 119.970392ms
+        duration: 113.651517ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -113,26 +113,26 @@ interactions:
                 - "1"
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots?include_deleted=false&order_by=created_at_asc&page=1
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 4521
-        body: '{"snapshots":[{"id":"394a7cc9-f236-4fdb-b04a-b7e40f44d4e0", "name":"snap-windows-configured", "parent_volume":{"id":"425394e3-34de-4afc-9fd2-461c3fc5b8a7", "name":"Windows Server 2022_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":25000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-10-21T16:49:55.784568Z", "updated_at":"2025-10-21T16:49:55.784568Z", "references":[], "status":"available", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"27653438-1c9b-40b3-b734-985080000738", "name":"snap-windows-configured-larger", "parent_volume":{"id":"425394e3-34de-4afc-9fd2-461c3fc5b8a7", "name":"Windows Server 2022_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":40000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-10T15:53:12.265541Z", "updated_at":"2025-11-10T15:53:12.265541Z", "references":[], "status":"available", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"1d6c36f5-bffb-40f1-89e4-2674e08a9c67", "name":"image-windows-configured_snap_0", "parent_volume":{"id":"425394e3-34de-4afc-9fd2-461c3fc5b8a7", "name":"Windows Server 2022_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":40000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-10T15:53:34.066522Z", "updated_at":"2025-11-10T15:53:34.066522Z", "references":[], "status":"in_use", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"706c3811-7240-40d8-86fe-285428572de5", "name":"snp-eager-varahamihira", "parent_volume":{"id":"28e01421-81ed-440f-9a45-c1af2a1b5082", "name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-24T18:53:15.025069Z", "updated_at":"2025-11-24T18:53:15.025069Z", "references":[], "status":"available", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}, {"id":"c963c50d-dbdb-4286-8e1d-eca5d8ec1f13", "name":"snp-gifted-ride", "parent_volume":{"id":"560c79c0-10d2-4117-801e-086bc1b02895", "name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-24T18:59:16.824951Z", "updated_at":"2025-11-24T18:59:16.824951Z", "references":[], "status":"available", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}, {"id":"564a09ee-571a-4c9f-9a58-f9ec06404206", "name":"image_to-reboot_2025-11-25_14-46_snap_0", "parent_volume":{"id":"a9539f04-dc7f-472f-8a28-1b476b003184", "name":"Ubuntu 24.04 Noble Numbat_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":15000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-25T14:46:18.671517Z", "updated_at":"2025-11-25T14:46:18.671517Z", "references":[], "status":"in_use", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"1de105c1-9d6a-4318-a871-819e91f7e483", "name":"cli-snp-reverent-bartik", "parent_volume":{"id":"560c79c0-10d2-4117-801e-086bc1b02895", "name":"Ubuntu 20.04 Focal Fossa_sbs_volume_0", "type":"sbs_5k", "status":"available"}, "size":10000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-25T19:43:07.108202Z", "updated_at":"2025-11-25T19:43:07.108202Z", "references":[], "status":"available", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"7580db29-8a33-466f-bd5c-8e7419b4fce9", "name":"cli-snp-infallible-wilson", "parent_volume":null, "size":25000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-25T19:43:32.547926Z", "updated_at":"2025-11-25T19:43:32.547926Z", "references":[], "status":"available", "tags":[], "class":"sbs", "zone":"fr-par-1"}, {"id":"734df84b-f08c-4f5d-a51b-c57e165edddb", "name":"snp-nervous-elbakyan", "parent_volume":null, "size":10000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-27T14:26:48.176178Z", "updated_at":"2025-11-27T14:26:56.008775Z", "references":[], "status":"available", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}, {"id":"01fa9df6-f507-4a14-ba81-6ea07ac817ea", "name":"snp-relaxed-lalande", "parent_volume":null, "size":10000000000, "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-11-27T15:38:49.726285Z", "updated_at":"2025-11-27T15:38:57.686926Z", "references":[], "status":"available", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}], "total_count":10}'
+        content_length: 1444
+        body: '{"snapshots":[{"id":"394a7cc9-f236-4fdb-b04a-b7e40f44d4e0","name":"snap-windows-configured","parent_volume":null,"size":25000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-10-21T16:49:55.784568Z","updated_at":"2025-10-21T16:49:55.784568Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1","public":false},{"id":"27653438-1c9b-40b3-b734-985080000738","name":"snap-windows-configured-larger","parent_volume":null,"size":40000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-11-10T15:53:12.265541Z","updated_at":"2025-11-10T15:53:12.265541Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1","public":false},{"id":"1d6c36f5-bffb-40f1-89e4-2674e08a9c67","name":"image-windows-configured_snap_0","parent_volume":null,"size":40000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-11-10T15:53:34.066522Z","updated_at":"2025-11-10T15:53:34.066522Z","references":[],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1","public":false},{"id":"1f083742-68b5-4553-828d-5b0a26f01305","name":"foo","parent_volume":null,"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2026-06-02T14:20:56.153314Z","updated_at":"2026-06-02T14:36:39.345013Z","references":[],"status":"available","tags":["custom","packer"],"class":"sbs","zone":"fr-par-1","public":false}],"total_count":4}'
         headers:
             Content-Length:
-                - "4521"
+                - "1444"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:16 GMT
+                - Tue, 02 Jun 2026 16:18:38 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -140,44 +140,44 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 098813be-c0c2-4ba7-bd86-1da7e36dd066
+                - 7b355879-9fc6-4d0e-b1e6-36a37c6867df
         status: 200 OK
         code: 200
-        duration: 44.802936ms
+        duration: 62.304094ms
     - id: 3
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 926
+        content_length: 957
         host: api.scaleway.com
-        body: '{"name":"packer-692889f4-35ac-30c8-8434-1e6c2b975ab2","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","boot_type":"local","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="]}'
+        body: '{"name":"packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf","commercial_type":"PRO2-XXS","image":"ubuntu_jammy","boot_type":"local","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["devtools","provider","packer","AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="]}'
         headers:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2528
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:17.435548+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 2633
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:38.723794+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2528"
+                - "2633"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:17 GMT
+                - Tue, 02 Jun 2026 16:18:39 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -185,10 +185,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c8f75e55-20de-40fc-978d-feaa6355c53e
+                - 3a93034e-9bc5-4907-9a4e-ffb7719c6acf
         status: 201 Created
         code: 201
-        duration: 519.262463ms
+        duration: 524.458684ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -201,15 +201,15 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4/action
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce/action
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 357
-        body: '{"task": {"id": "b337444e-2036-46ac-b999-a02dd41165c8", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4/action", "href_result": "/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4", "started_at": "2025-11-27T17:27:18.221430+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "41d9f74d-1b77-4bd0-b941-3b5d7ed7df0e", "description": "server_batch_poweron", "status": "pending", "href_from": "/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce/action", "href_result": "/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce", "started_at": "2026-06-02T16:18:39.572134+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "357"
@@ -218,11 +218,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:18 GMT
+                - Tue, 02 Jun 2026 16:18:39 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b337444e-2036-46ac-b999-a02dd41165c8
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/41d9f74d-1b77-4bd0-b941-3b5d7ed7df0e
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -230,10 +230,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 27d851ed-fd7a-4e48-8a51-eef9310b3d82
+                - 5e32570c-52e8-44f9-b7ee-f68257659395
         status: 202 Accepted
         code: 202
-        duration: 404.85753ms
+        duration: 483.11868ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -243,26 +243,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2550
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:17.875614+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3179
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "starting", "protected": false, "state_detail": "allocating node", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:39.154759+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2550"
+                - "3179"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:18 GMT
+                - Tue, 02 Jun 2026 16:18:39 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -270,10 +270,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a0eddce-fa59-430c-ba84-562832c7685e
+                - d83cd0eb-05d2-42fb-9359-c200f7436a28
         status: 200 OK
         code: 200
-        duration: 103.66239ms
+        duration: 109.856158ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -283,26 +283,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3210
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}, "public_ips": [{"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:20.517070+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3313
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:41.327602+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3210"
+                - "3313"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:23 GMT
+                - Tue, 02 Jun 2026 16:18:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -310,10 +310,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - c360c52a-018c-4168-9fc7-aac7ed29df70
+                - 590c0833-151e-4d47-b983-c40561c928e8
         status: 200 OK
         code: 200
-        duration: 83.550699ms
+        duration: 112.626003ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -323,26 +323,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3210
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}, "public_ips": [{"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:20.517070+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3313
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "running", "protected": false, "state_detail": "booting kernel", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:41.327602+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3210"
+                - "3313"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:23 GMT
+                - Tue, 02 Jun 2026 16:18:44 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -350,10 +350,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f932315b-7648-436e-a2bd-596074298e4b
+                - 6510d4b3-c267-4b85-806b-e15eb0229602
         status: 200 OK
         code: 200
-        duration: 108.77341ms
+        duration: 98.620424ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -366,15 +366,15 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4/action
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce/action
         method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 352
-        body: '{"task": {"id": "b3a5f916-5e2e-4da0-91a5-727af55f0a2b", "description": "server_poweroff", "status": "pending", "href_from": "/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4/action", "href_result": "/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4", "started_at": "2025-11-27T17:27:23.733170+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+        body: '{"task": {"id": "875943d4-33e7-4931-87de-b14ccb00dd3e", "description": "server_poweroff", "status": "pending", "href_from": "/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce/action", "href_result": "/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce", "started_at": "2026-06-02T16:18:45.101233+00:00", "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
         headers:
             Content-Length:
                 - "352"
@@ -383,11 +383,11 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:23 GMT
+                - Tue, 02 Jun 2026 16:18:45 GMT
             Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/b3a5f916-5e2e-4da0-91a5-727af55f0a2b
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/875943d4-33e7-4931-87de-b14ccb00dd3e
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -395,10 +395,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fd94d74e-a0e3-4342-b58f-0c985b40d0ac
+                - 4a4d2731-ac71-454e-a516-f5906cadee09
         status: 202 Accepted
         code: 202
-        duration: 199.962955ms
+        duration: 208.056645ms
     - id: 9
       request:
         proto: HTTP/1.1
@@ -408,26 +408,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 3170
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}, "public_ips": [{"id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3", "address": "163.172.185.249", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "9da5e42b-7f4b-46ca-a6bd-601087bff4d3"}], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3273
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:44.957751+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "3170"
+                - "3273"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:23 GMT
+                - Tue, 02 Jun 2026 16:18:45 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -435,10 +435,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b03ebd56-ad2c-4d85-96f9-8a100be137af
+                - 32b99454-b425-401f-be7f-b029157f12ad
         status: 200 OK
         code: 200
-        duration: 115.413452ms
+        duration: 100.452194ms
     - id: 10
       request:
         proto: HTTP/1.1
@@ -448,26 +448,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3273
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "pending", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:44.957751+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "3273"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:28 GMT
+                - Tue, 02 Jun 2026 16:18:50 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -475,10 +475,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e8c07f93-4fff-43d8-9075-4594523b4ef6
+                - 7f028e61-a72b-4726-9bff-4fd16c9ab7b6
         status: 200 OK
         code: 200
-        duration: 113.196661ms
+        duration: 115.544577ms
     - id: 11
       request:
         proto: HTTP/1.1
@@ -488,26 +488,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3275
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:44.957751+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "3275"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:34 GMT
+                - Tue, 02 Jun 2026 16:18:55 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -515,10 +515,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9e81fa65-4f19-41b1-8cc4-b9b0d2b91c7d
+                - e69fd7d5-78f5-4d9f-b295-4b34dd4750a0
         status: 200 OK
         code: 200
-        duration: 97.528612ms
+        duration: 143.93491ms
     - id: 12
       request:
         proto: HTTP/1.1
@@ -528,26 +528,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3273
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:44.957751+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "3273"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:39 GMT
+                - Tue, 02 Jun 2026 16:19:00 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -555,10 +555,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - d756b9c3-3899-4615-aee2-453201366fff
+                - c621c44c-44b5-445f-a38b-621147313b13
         status: 200 OK
         code: 200
-        duration: 88.689822ms
+        duration: 112.64855ms
     - id: 13
       request:
         proto: HTTP/1.1
@@ -568,26 +568,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 3273
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopping", "protected": false, "state_detail": "booted", "public_ip": {"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}, "public_ips": [{"id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb", "address": "163.172.139.25", "dynamic": true, "gateway": "62.210.0.1", "netmask": "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "d7ab55a0-6660-4f9e-bb37-cc266b5567fb"}], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:18:44.957751+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "11", "hypervisor_id": "101", "node_id": "17"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "3273"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:44 GMT
+                - Tue, 02 Jun 2026 16:19:05 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -595,10 +595,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 05f910ef-0680-4559-a36f-af2bf3b8085d
+                - 8f73238d-3be2-4718-99f9-6e3970304b6b
         status: 200 OK
         code: 200
-        duration: 102.840819ms
+        duration: 122.506108ms
     - id: 14
       request:
         proto: HTTP/1.1
@@ -608,26 +608,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 2633
+        body: '{"server": {"id": "4c30fb58-64ed-4a58-9d52-976e749d04ce", "name": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-6a1f025d-9a97-e6c4-019b-ad414ad322cf", "image": {"id": "4481c662-2357-432f-b0fd-dd6470c08c49", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "c75ef419-9a29-4fda-bd73-5de42af425b0", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2026-05-12T15:06:26.845576+00:00", "modification_date": "2026-05-12T15:06:26.845576+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "7cb27a97-52b4-4587-9495-8491d2359af8", "state": "available", "zone": "fr-par-1"}}, "tags": ["devtools", "provider", "packer", "AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQDnw/eL2k430IJEXNzgQBI52zPklP511RtKNnqXiPbnGeViFBSaspUwQbR+5rSjK/XlO7WCJzat94mZ/JAtF+m+by7TFRGBI6u4aWDJfjBP3HD1vIhStp9jV1Rhe0oz7uEXW80EZW9gCR3IDIzVpiaWmdCHV2lkEDB+llnBo0RktAdJ8QZI3f5z+rhHSKmmsd2sk5T61BhU0jEu/8o++f5C12uc/scSeKRjaRzSi8zo6tbxnOoogLEyaSj8kyPMjKf7Wymld1OOMrqzlgOMfopV7vEG/Dx6vivNDevzNMlYBPTdZqJwcIGxQID6K+MLI7yiC/fxRaWtXWHvz6JwF+R1lVHnnf7JEi77vkUZ44QnMGdbgBlEJo107EEEJAC+jpULuxu28oxvNIzIS/hioZoBFw4Xvez/vhxKhxWAFCo4VNnAKw87fm5ex/Cn1CW3XOdctTgX7dCW8TmK2Trnxs1L1maSgibxjG3+eGr+rSjzcDfS6Kr31SKWsADAwa/oSQQV34ThZZ23nrmVP80amDLn/1AnFpY8z3yIewXslPUXg0mMsjWC24IChdvXdShZv7xhhyyoIQDnfkAVbZgJa4aNDVQag+ci1gKGEQ+gNu5Wft6PK+SU/wkcdDjtEZ23X41R77i1GQ2TivYucJMPlzYMLoGX6DM6tevlOlnOvEcvuQ=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:01:15:24:1b", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2026-06-02T16:18:38.723794+00:00", "modification_date": "2026-06-02T16:19:10.726326+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false, "dns": "4c30fb58-64ed-4a58-9d52-976e749d04ce.pub.instances.scw.cloud"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "2633"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:49 GMT
+                - Tue, 02 Jun 2026 16:19:10 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -635,39 +635,42 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a6f7c44a-70d8-4b93-9f3b-4689f546c07e
+                - d121d320-e314-4dfd-a552-e93bdf2e71d2
         status: 200 OK
         code: 200
-        duration: 86.995474ms
+        duration: 107.604317ms
     - id: 15
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 170
         host: api.scaleway.com
+        body: '{"volume_id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"snp-dreamy-booth","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["devtools","provider","packer"]}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 498
+        body: '{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":{"id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:10.980776Z","references":[],"status":"creating","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}'
         headers:
             Content-Length:
-                - "2644"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:54 GMT
+                - Tue, 02 Jun 2026 16:19:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -675,10 +678,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0cfa95e3-77eb-4415-a450-7d4675b129f8
+                - ab14c12f-3849-4566-a55e-c90144b086ac
         status: 200 OK
         code: 200
-        duration: 125.317959ms
+        duration: 285.586102ms
     - id: 16
       request:
         proto: HTTP/1.1
@@ -688,26 +691,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/9330c98b-e509-47ad-b605-dd51520ab11b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 498
+        body: '{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":{"id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:10.980776Z","references":[],"status":"creating","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}'
         headers:
             Content-Length:
-                - "2644"
+                - "498"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:27:59 GMT
+                - Tue, 02 Jun 2026 16:19:11 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -715,10 +718,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 3b74e7d0-3464-47c8-abcc-1fd4e8ebfb44
+                - 76c6e207-8b98-489f-8ad4-2b5d8eed1d41
         status: 200 OK
         code: 200
-        duration: 102.35054ms
+        duration: 48.223058ms
     - id: 17
       request:
         proto: HTTP/1.1
@@ -728,26 +731,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/9330c98b-e509-47ad-b605-dd51520ab11b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 499
+        body: '{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":{"id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:10.980776Z","references":[],"status":"available","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}'
         headers:
             Content-Length:
-                - "2644"
+                - "499"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:04 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -755,39 +758,44 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fc0a4006-5045-4744-bbc8-c22681d74fc9
+                - b67906e1-f158-4f37-9540-b494ea7a27a2
         status: 200 OK
         code: 200
-        duration: 96.151957ms
+        duration: 56.065852ms
     - id: 18
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 0
+        content_length: 201
         host: api.scaleway.com
+        body: '{"name":"packer-e2e-simple","root_volume":"9330c98b-e509-47ad-b605-dd51520ab11b","arch":"x86_64","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["devtools","provider","packer"],"public":false}'
         headers:
+            Content-Type:
+                - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
-        method: GET
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+        method: POST
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 609
+        body: '{"image": {"id": "ae952dae-ddbd-4f5a-bf08-2a6e86938818", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "9330c98b-e509-47ad-b605-dd51520ab11b", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T16:19:16.347152+00:00", "modification_date": "2026-06-02T16:19:16.347152+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "609"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:09 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/ae952dae-ddbd-4f5a-bf08-2a6e86938818
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -795,10 +803,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - f27bc712-75df-4acc-9db8-de24d4e1eeb6
-        status: 200 OK
-        code: 200
-        duration: 113.880326ms
+                - a6a90259-a955-4c93-9f54-d1bd8246563a
+        status: 201 Created
+        code: 201
+        duration: 242.212466ms
     - id: 19
       request:
         proto: HTTP/1.1
@@ -808,26 +816,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/ae952dae-ddbd-4f5a-bf08-2a6e86938818
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 2644
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopping", "protected": false, "state_detail": "stopping", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:27:23.589388+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": {"zone_id": "fr-par-1", "platform_id": "14", "cluster_id": "96", "hypervisor_id": "901", "node_id": "37"}, "maintenances": [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
+        content_length: 609
+        body: '{"image": {"id": "ae952dae-ddbd-4f5a-bf08-2a6e86938818", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "9330c98b-e509-47ad-b605-dd51520ab11b", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T16:19:16.347152+00:00", "modification_date": "2026-06-02T16:19:16.347152+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}}'
         headers:
             Content-Length:
-                - "2644"
+                - "609"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:14 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -835,259 +843,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 6dcd5ee5-2e52-4eaf-87e1-38c16c3caea7
+                - 8d62cd01-4a0d-4ff3-b88b-3b5e32b8cda1
         status: 200 OK
         code: 200
-        duration: 121.930513ms
+        duration: 89.576543ms
     - id: 20
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 2528
-        body: '{"server": {"id": "d1bd2eef-9fb2-490b-adc8-21e7933370f4", "name": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "arch": "x86_64", "commercial_type": "PRO2-XXS", "boot_type": "local", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "hostname": "packer-692889f4-35ac-30c8-8434-1e6c2b975ab2", "image": {"id": "6d3c053e-c728-4294-b23a-560b62a4d592", "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db", "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type": "sbs_snapshot", "id": "36b4ce54-c67a-4f68-ab74-839515834352", "size": 0, "name": ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-09-12T09:11:41.420846+00:00", "modification_date": "2025-09-12T09:11:41.420846+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2", "state": "available", "zone": "fr-par-1"}}, "tags": ["AUTHORIZED_KEY=ssh-rsa_AAAAB3NzaC1yc2EAAAADAQABAAACAQC1P+mIqigvHZxdVYFfE1lP9BX+5hCtf57ghRlnon5UbtM6dgBGZgtnOgR1uD/B0mr8tPppIHeNpMai0SPNg0DKgbfb/ApqYVUn4ydyMT9jltyW7SniLoPKhr7/M1wyPuJg65sYM6m4drJ6ePy9MqfRTQKahfctP4sucF0nwAkdI0gnGhjWs3PZQBS2n/kg590tQE3FzbAz1++2PEBwz9Z8VNcJAC+e9ukJvIAFDxquJ4camrRWWvbE8MUPERMAQwP1DiY5WvV+FkWhFbnRepZuLwePsm5DJIFDceDnDCfeIipmvDh613Vi/xYXcn8EQR/Uy2OIW8Om4Z3KBMuOjzlL4JLWyf30XDdNPnzWSYlSaZFyffqkjkDIeXiX0PFvySQZTum+pcQL98M+EqK57c2ErhnYgedqq0Gb3bmqNRlGNjV4YzwQP5xEouIHgeKt9921C4DS5yTu8unupC3f/qOuv9EJ4DGtQnG1dQQwNKjsHCyMy4N7QJZM67hc3/15bk664RgU1O1gBmtMPS4InH9c8iPhswuqHXoXccy0QlRqLChu8DB+obV15P5eSHsDF8GSjeOs9eLbOd7l2FWpW6mTuk/U+bIaTFHNkiMZX2/Q7YdktM8x6BKWYjn9pruoBIlutJKSL0cQQV30YupI1FxsiJrIAN1IlyCn0PIseWqTyw=="], "state": "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:d6:dd:05", "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-11-27T17:27:17.435548+00:00", "modification_date": "2025-11-27T17:28:16.474211+00:00", "bootscript": null, "security_group": {"id": "96320557-68cb-45f1-9f9b-587a3c3f458c", "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service": false}}'
-        headers:
-            Content-Length:
-                - "2528"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 767ce9e3-d04f-4c60-a8ac-4577f5a64b61
-        status: 200 OK
-        code: 200
-        duration: 91.774163ms
-    - id: 21
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 171
-        host: api.scaleway.com
-        body: '{"volume_id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2","name":"snp-funny-lamport","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["devtools","provider","packer"]}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 500
-        body: '{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":{"id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2", "name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:20.155975Z", "references":[], "status":"creating", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "500"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 473553da-1793-4ee0-b6eb-23d753facda2
-        status: 200 OK
-        code: 200
-        duration: 522.522189ms
-    - id: 22
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/38ff451a-eaa2-44a3-99ef-7a5e746c18e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 500
-        body: '{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":{"id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2", "name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:20.155975Z", "references":[], "status":"creating", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "500"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:20 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 6a5de9cd-ce53-4d14-99a9-48cf8ea71d58
-        status: 200 OK
-        code: 200
-        duration: 281.136679ms
-    - id: 23
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/38ff451a-eaa2-44a3-99ef-7a5e746c18e7
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 501
-        body: '{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":{"id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2", "name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:20.155975Z", "references":[], "status":"available", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}'
-        headers:
-            Content-Length:
-                - "501"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - 566e9aa8-d427-42ba-89e2-61d98f9d232e
-        status: 200 OK
-        code: 200
-        duration: 271.607567ms
-    - id: 24
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 201
-        host: api.scaleway.com
-        body: '{"name":"packer-e2e-simple","root_volume":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7","arch":"x86_64","project":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":["devtools","provider","packer"],"public":false}'
-        headers:
-            Content-Type:
-                - application/json
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
-        method: POST
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 609
-        body: '{"image": {"id": "765fb528-8d8c-4f7f-8b38-a4e8bbecb071", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:28:26.232837+00:00", "modification_date": "2025-11-27T17:28:26.232837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "609"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:26 GMT
-            Location:
-                - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/765fb528-8d8c-4f7f-8b38-a4e8bbecb071
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - f1887576-c2c3-459a-a9b3-a09fbdb9ddee
-        status: 201 Created
-        code: 201
-        duration: 659.940428ms
-    - id: 25
-      request:
-        proto: HTTP/1.1
-        proto_major: 1
-        proto_minor: 1
-        content_length: 0
-        host: api.scaleway.com
-        headers:
-            User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/765fb528-8d8c-4f7f-8b38-a4e8bbecb071
-        method: GET
-      response:
-        proto: HTTP/2.0
-        proto_major: 2
-        proto_minor: 0
-        content_length: 609
-        body: '{"image": {"id": "765fb528-8d8c-4f7f-8b38-a4e8bbecb071", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:28:26.232837+00:00", "modification_date": "2025-11-27T17:28:26.232837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}}'
-        headers:
-            Content-Length:
-                - "609"
-            Content-Security-Policy:
-                - default-src 'none'; frame-ancestors 'none'
-            Content-Type:
-                - application/json
-            Date:
-                - Thu, 27 Nov 2025 17:28:26 GMT
-            Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
-            Strict-Transport-Security:
-                - max-age=63072000
-            X-Content-Type-Options:
-                - nosniff
-            X-Frame-Options:
-                - DENY
-            X-Request-Id:
-                - a4ea0810-c802-4fc8-90ad-4e88cd8bdeb5
-        status: 200 OK
-        code: 200
-        duration: 68.63511ms
-    - id: 26
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1099,26 +859,26 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/volumes/96cf50b6-2d61-467e-90b2-5c545c55d7c2
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/volumes/7cb27a97-52b4-4587-9495-8491d2359af8
         method: PATCH
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 737
-        body: '{"id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2", "name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:27:17.572915Z", "updated_at":"2025-11-27T17:27:17.572915Z", "references":[{"id":"42cf34b6-6d68-4736-a88e-0bdebd39e2b6", "product_resource_type":"instance_server", "product_resource_id":"d1bd2eef-9fb2-490b-adc8-21e7933370f4", "created_at":"2025-11-27T17:27:17.572915Z", "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"36b4ce54-c67a-4f68-ab74-839515834352", "status":"in_use", "tags":["devtools", "provider", "packer"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+        content_length: 734
+        body: '{"id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:18:38.871329Z","updated_at":"2026-06-02T16:18:38.871329Z","references":[{"id":"a7b2f7ea-ea46-4c73-91ce-4032a75a90fb","product_resource_type":"instance_server","product_resource_id":"4c30fb58-64ed-4a58-9d52-976e749d04ce","created_at":"2026-06-02T16:18:38.871329Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"c75ef419-9a29-4fda-bd73-5de42af425b0","status":"in_use","tags":["devtools","provider","packer"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"kms_key_id":null,"zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "737"
+                - "734"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:26 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1126,11 +886,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fa762e87-29ec-404f-9d67-71837156bce2
+                - 6311859e-82fd-409f-ac27-78730831d9de
         status: 200 OK
         code: 200
-        duration: 82.631856ms
-    - id: 27
+        duration: 160.800921ms
+    - id: 21
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1139,8 +899,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d1bd2eef-9fb2-490b-adc8-21e7933370f4
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c30fb58-64ed-4a58-9d52-976e749d04ce
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1154,9 +914,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1164,11 +924,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b6ea89c5-36f2-49b3-bf08-0bc30f2f994f
+                - ea93ba8e-a095-4b10-ac7d-41c7bcac163f
         status: 204 No Content
         code: 204
-        duration: 205.098426ms
-    - id: 28
+        duration: 193.523512ms
+    - id: 22
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1177,15 +937,15 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96cf50b6-2d61-467e-90b2-5c545c55d7c2
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7cb27a97-52b4-4587-9495-8491d2359af8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 143
-        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2"}'
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "7cb27a97-52b4-4587-9495-8491d2359af8"}'
         headers:
             Content-Length:
                 - "143"
@@ -1194,9 +954,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:16 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1204,11 +964,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - b9e6dc93-f788-41a4-863e-265ad30023d9
+                - 0001b80a-73d9-458a-b5dc-88db1aab8539
         status: 404 Not Found
         code: 404
-        duration: 35.470153ms
-    - id: 29
+        duration: 38.436985ms
+    - id: 23
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1217,15 +977,15 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/96cf50b6-2d61-467e-90b2-5c545c55d7c2
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7cb27a97-52b4-4587-9495-8491d2359af8
         method: DELETE
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
         content_length: 143
-        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "96cf50b6-2d61-467e-90b2-5c545c55d7c2"}'
+        body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume", "resource_id": "7cb27a97-52b4-4587-9495-8491d2359af8"}'
         headers:
             Content-Length:
                 - "143"
@@ -1234,9 +994,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1244,11 +1004,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - a07a60bc-3862-42f4-8ee9-6c30d0d18f06
+                - af4358bb-232a-4e10-a531-ef86a2de4c39
         status: 404 Not Found
         code: 404
-        duration: 30.046796ms
-    - id: 30
+        duration: 37.792906ms
+    - id: 24
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1257,26 +1017,26 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96cf50b6-2d61-467e-90b2-5c545c55d7c2
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7cb27a97-52b4-4587-9495-8491d2359af8
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 530
-        body: '{"id":"96cf50b6-2d61-467e-90b2-5c545c55d7c2", "name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:27:17.572915Z", "updated_at":"2025-11-27T17:28:27.220518Z", "references":[], "parent_snapshot_id":"36b4ce54-c67a-4f68-ab74-839515834352", "status":"available", "tags":["devtools", "provider", "packer"], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-11-27T17:28:27.220518Z", "zone":"fr-par-1"}'
+        content_length: 514
+        body: '{"id":"7cb27a97-52b4-4587-9495-8491d2359af8","name":"Ubuntu 22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:18:38.871329Z","updated_at":"2026-06-02T16:19:17.007747Z","references":[],"parent_snapshot_id":"c75ef419-9a29-4fda-bd73-5de42af425b0","status":"available","tags":["devtools","provider","packer"],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2026-06-02T16:19:17.007747Z","zone":"fr-par-1"}'
         headers:
             Content-Length:
-                - "530"
+                - "514"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1284,11 +1044,11 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 84686eef-161b-448d-967f-75219491e613
+                - 00e931d3-febe-495d-83a0-76677c1fdd8b
         status: 200 OK
         code: 200
-        duration: 44.110698ms
-    - id: 31
+        duration: 66.878754ms
+    - id: 25
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -1297,8 +1057,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.1; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.1; linux/amd64)
-        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/96cf50b6-2d61-467e-90b2-5c545c55d7c2
+                - scaleway-sdk-go/v1.0.0-beta.35.0.20251020071439-b2bca397788f (go1.25.10; linux; amd64) Packer/1.1.1-dev (+https://www.packer.io/; go1.25.10; linux/amd64)
+        url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7cb27a97-52b4-4587-9495-8491d2359af8
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -1312,9 +1072,9 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:17 GMT
             Server:
-                - Scaleway API Gateway (fr-par-2;edge01)
+                - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
                 - max-age=63072000
             X-Content-Type-Options:
@@ -1322,7 +1082,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ffd828f9-1447-410b-9cc3-a1a42779aee4
+                - dd6d2070-49e9-41db-8fbe-eb5ad923011c
         status: 204 No Content
         code: 204
-        duration: 80.531134ms
+        duration: 92.709288ms

--- a/internal/tests/testdata/simple.cassette.yaml
+++ b/internal/tests/testdata/simple.cassette.yaml
@@ -17,7 +17,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -25,7 +25,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 612
-        body: '{"images": [{"id": "765fb528-8d8c-4f7f-8b38-a4e8bbecb071", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:28:26.232837+00:00", "modification_date": "2025-11-27T17:28:26.232837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "ae952dae-ddbd-4f5a-bf08-2a6e86938818", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "9330c98b-e509-47ad-b605-dd51520ab11b", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T16:19:16.347152+00:00", "modification_date": "2026-06-02T16:19:16.347152+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
                 - "612"
@@ -34,7 +34,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:27 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Link:
                 - </images?page=1&per_page=50&name=packer-e2e-simple&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
@@ -46,12 +46,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 9a1c9d18-c0eb-4781-b66f-d482ce46752a
+                - dab3e33c-aad0-4fd3-a69c-db72f6e65637
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 234.698032ms
+        duration: 257.695693ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -61,24 +61,24 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/38ff451a-eaa2-44a3-99ef-7a5e746c18e7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/9330c98b-e509-47ad-b605-dd51520ab11b
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 598
-        body: '{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":null, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:26.273205Z", "references":[{"id":"f2ba0516-9f75-4713-88d7-804703998c97", "product_resource_type":"instance_image", "product_resource_id":"765fb528-8d8c-4f7f-8b38-a4e8bbecb071", "created_at":"2025-11-27T17:28:26.273205Z", "type":"link", "status":"attached"}], "status":"in_use", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}'
+        content_length: 594
+        body: '{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":null,"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:16.377925Z","references":[{"id":"2eefb5ee-8c52-4d11-af45-b5e56a0ec8af","product_resource_type":"instance_image","product_resource_id":"ae952dae-ddbd-4f5a-bf08-2a6e86938818","created_at":"2026-06-02T16:19:16.377925Z","type":"link","status":"attached"}],"status":"in_use","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}'
         headers:
             Content-Length:
-                - "598"
+                - "594"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:28 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -88,10 +88,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e59e12ee-461f-4989-a8a8-ad66b97ab0c2
+                - c2801e6c-b2d9-4a17-92d5-23b6015d87d9
         status: 200 OK
         code: 200
-        duration: 752.248914ms
+        duration: 55.743086ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -110,7 +110,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots?include_deleted=false&name=snp-&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -118,7 +118,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 402
-        body: '{"snapshots":[{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":null, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:26.273205Z", "references":[], "status":"in_use", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}], "total_count":1}'
+        body: '{"snapshots":[{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":null,"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:16.377925Z","references":[],"status":"in_use","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}],"total_count":1}'
         headers:
             Content-Length:
                 - "402"
@@ -127,7 +127,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:28 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -137,10 +137,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 0ef48187-ca08-4d9f-8edc-0ef68a60edbd
+                - 4fa5e337-6bac-4c3c-a23d-4010b10fdeb6
         status: 200 OK
         code: 200
-        duration: 44.840838ms
+        duration: 62.661202ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -153,7 +153,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes?project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -170,7 +170,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:28 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Link:
                 - </volumes?page=0&per_page=100&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
@@ -182,12 +182,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 5f80c4d0-0d36-4d0e-8539-7c222e5c1a57
+                - 5bd0cfc7-0e33-4257-837c-688e46978ef4
             X-Total-Count:
                 - "0"
         status: 200 OK
         code: 200
-        duration: 76.400023ms
+        duration: 77.990638ms
     - id: 4
       request:
         proto: HTTP/1.1
@@ -204,24 +204,24 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/fr-par-1/volumes?include_deleted=false&order_by=created_at_asc&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
         proto: HTTP/2.0
         proto_major: 2
         proto_minor: 0
-        content_length: 31
-        body: '{"volumes":[], "total_count":0}'
+        content_length: 30
+        body: '{"volumes":[],"total_count":0}'
         headers:
             Content-Length:
-                - "31"
+                - "30"
             Content-Security-Policy:
                 - default-src 'none'; frame-ancestors 'none'
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:28 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -231,10 +231,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 67a36665-b3cf-4ef5-b541-075f33dbb00d
+                - d50de198-704b-4ebe-832c-e0f78b29335e
         status: 200 OK
         code: 200
-        duration: 62.232635ms
+        duration: 57.74716ms
     - id: 5
       request:
         proto: HTTP/1.1
@@ -251,7 +251,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?name=packer-e2e-simple&page=1&project=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -259,7 +259,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 612
-        body: '{"images": [{"id": "765fb528-8d8c-4f7f-8b38-a4e8bbecb071", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2025-11-27T17:28:26.232837+00:00", "modification_date": "2025-11-27T17:28:26.232837+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}]}'
+        body: '{"images": [{"id": "ae952dae-ddbd-4f5a-bf08-2a6e86938818", "name": "packer-e2e-simple", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "root_volume": {"volume_type": "sbs_snapshot", "id": "9330c98b-e509-47ad-b605-dd51520ab11b", "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64", "creation_date": "2026-06-02T16:19:16.347152+00:00", "modification_date": "2026-06-02T16:19:16.347152+00:00", "default_bootscript": null, "from_server": "", "state": "available", "tags": ["devtools", "provider", "packer"], "zone": "fr-par-1"}]}'
         headers:
             Content-Length:
                 - "612"
@@ -268,7 +268,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:29 GMT
+                - Tue, 02 Jun 2026 16:19:18 GMT
             Link:
                 - </images?page=1&per_page=50&name=packer-e2e-simple&project=19a4819b-24bf-4d44-969f-935ef0061b71>; rel="last"
             Server:
@@ -280,12 +280,12 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - ee276225-ac16-4f70-8450-ec249c6f7317
+                - e5ddc94d-a0e4-431c-9baf-fc057d1a0c1b
             X-Total-Count:
                 - "1"
         status: 200 OK
         code: 200
-        duration: 213.725637ms
+        duration: 191.584921ms
     - id: 6
       request:
         proto: HTTP/1.1
@@ -295,8 +295,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/765fb528-8d8c-4f7f-8b38-a4e8bbecb071
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/ae952dae-ddbd-4f5a-bf08-2a6e86938818
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -310,7 +310,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:29 GMT
+                - Tue, 02 Jun 2026 16:19:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -320,10 +320,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - fab5afa4-76e7-44c5-b105-8d70ad21c96c
+                - 41d6463f-5704-45ad-ab33-890d51d2e779
         status: 204 No Content
         code: 204
-        duration: 347.588052ms
+        duration: 361.628937ms
     - id: 7
       request:
         proto: HTTP/1.1
@@ -344,7 +344,7 @@ interactions:
                 - 19a4819b-24bf-4d44-969f-935ef0061b71
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
         url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots?include_deleted=false&name=snp-&order_by=created_at_asc&page=1&project_id=19a4819b-24bf-4d44-969f-935ef0061b71
         method: GET
       response:
@@ -352,7 +352,7 @@ interactions:
         proto_major: 2
         proto_minor: 0
         content_length: 402
-        body: '{"snapshots":[{"id":"38ff451a-eaa2-44a3-99ef-7a5e746c18e7", "name":"snp-funny-lamport", "parent_volume":null, "size":10000000000, "project_id":"19a4819b-24bf-4d44-969f-935ef0061b71", "created_at":"2025-11-27T17:28:20.155975Z", "updated_at":"2025-11-27T17:28:26.273205Z", "references":[], "status":"in_use", "tags":["devtools", "provider", "packer"], "class":"sbs", "zone":"fr-par-1"}], "total_count":1}'
+        body: '{"snapshots":[{"id":"9330c98b-e509-47ad-b605-dd51520ab11b","name":"snp-dreamy-booth","parent_volume":null,"size":10000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2026-06-02T16:19:10.980776Z","updated_at":"2026-06-02T16:19:16.377925Z","references":[],"status":"in_use","tags":["devtools","provider","packer"],"class":"sbs","zone":"fr-par-1","public":false}],"total_count":1}'
         headers:
             Content-Length:
                 - "402"
@@ -361,7 +361,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:29 GMT
+                - Tue, 02 Jun 2026 16:19:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -371,10 +371,10 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - 28de4a59-4e10-42cd-a370-d21a3631fe40
+                - 2f645026-2fb0-4c6b-b31b-45b859ae4396
         status: 200 OK
         code: 200
-        duration: 40.769778ms
+        duration: 49.118792ms
     - id: 8
       request:
         proto: HTTP/1.1
@@ -384,8 +384,8 @@ interactions:
         host: api.scaleway.com
         headers:
             User-Agent:
-                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.1; linux; amd64)
-        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/38ff451a-eaa2-44a3-99ef-7a5e746c18e7
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.25.10; linux; amd64)
+        url: https://api.scaleway.com/block/v1/zones/fr-par-1/snapshots/9330c98b-e509-47ad-b605-dd51520ab11b
         method: DELETE
       response:
         proto: HTTP/2.0
@@ -399,7 +399,7 @@ interactions:
             Content-Type:
                 - application/json
             Date:
-                - Thu, 27 Nov 2025 17:28:30 GMT
+                - Tue, 02 Jun 2026 16:19:19 GMT
             Server:
                 - Scaleway API Gateway (fr-par-2;edge02)
             Strict-Transport-Security:
@@ -409,7 +409,7 @@ interactions:
             X-Frame-Options:
                 - DENY
             X-Request-Id:
-                - e12c7c4b-e069-4b2e-9cc0-61d5363e1051
+                - b791854c-8241-41dc-85c1-b8cdb3aa32d5
         status: 204 No Content
         code: 204
-        duration: 770.16265ms
+        duration: 78.884589ms


### PR DESCRIPTION
This PR adds the possibility to apply tags to the temporary server used to build the image. 

A unique set of tags can be defined specifically for the server by using `server_tags`, and if the field is not set in the config, the server will be tagged with the set from the `tags` field.

To test this feature, a new field `keep_server` had to be implemented in order to prevent the automatic destruction of the server after building the image, and be able to run checks on it.

Closes #310 