### PR TITLE
fix: remove snapshot_name from config

### DIFF
--- a/builder/scaleway/config.go
+++ b/builder/scaleway/config.go
@@ -81,9 +81,6 @@ type Config struct {
 	// GP1-XS, GP1-S, GP1-M, GP1-L, GP1-XL,
 	// GPU-3070-S, RENDER-S, STARDUST1-S,
 	CommercialType string `mapstructure:"commercial_type" required:"true"`
-	// The name of the resulting snapshot that will
-	// appear in your account. Default packer-TIMESTAMP
-	SnapshotName string `mapstructure:"snapshot_name" required:"false"`
 	// The name of the resulting image that will appear in
 	// your account. Default packer-TIMESTAMP
 	ImageName string `mapstructure:"image_name" required:"false"`

--- a/builder/scaleway/config.hcl2spec.go
+++ b/builder/scaleway/config.hcl2spec.go
@@ -74,7 +74,6 @@ type FlatConfig struct {
 	APIURL                    *string                 `mapstructure:"api_url" cty:"api_url" hcl:"api_url"`
 	Image                     *string                 `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
 	CommercialType            *string                 `mapstructure:"commercial_type" required:"true" cty:"commercial_type" hcl:"commercial_type"`
-	SnapshotName              *string                 `mapstructure:"snapshot_name" required:"false" cty:"snapshot_name" hcl:"snapshot_name"`
 	ImageName                 *string                 `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	ServerName                *string                 `mapstructure:"server_name" required:"false" cty:"server_name" hcl:"server_name"`
 	Bootscript                *string                 `mapstructure:"bootscript" required:"false" cty:"bootscript" hcl:"bootscript"`
@@ -174,7 +173,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"api_url":                      &hcldec.AttrSpec{Name: "api_url", Type: cty.String, Required: false},
 		"image":                        &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"commercial_type":              &hcldec.AttrSpec{Name: "commercial_type", Type: cty.String, Required: false},
-		"snapshot_name":                &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"image_name":                   &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"server_name":                  &hcldec.AttrSpec{Name: "server_name", Type: cty.String, Required: false},
 		"bootscript":                   &hcldec.AttrSpec{Name: "bootscript", Type: cty.String, Required: false},

--- a/docs-partials/builder/scaleway/Config-not-required.mdx
+++ b/docs-partials/builder/scaleway/Config-not-required.mdx
@@ -4,9 +4,6 @@
   Will be fetched first from the [scaleway configuration file](https://github.com/scaleway/scaleway-sdk-go/blob/master/scw/README.md).
   It can also be specified via the environment variable SCW_API_URL
 
-- `snapshot_name` (string) - The name of the resulting snapshot that will
-  appear in your account. Default packer-TIMESTAMP
-
 - `image_name` (string) - The name of the resulting image that will appear in
   your account. Default packer-TIMESTAMP
 


### PR DESCRIPTION
#278 moved the field from the root of the config block to the volume definition blocks (`root_volume` and `block_volume`), as there will be one snapshot per volume, and not per image. 
But the field was not removed correctly and is still accepted in the root of the config, although it does not do anything anymore.

This PR removes the `snapshot_name` field from the root of the config block and from the documentation for good.

Closes #272 